### PR TITLE
ifndef POLLRDHUP, define POLLRDHUP = POLLHUP

### DIFF
--- a/cbits/eventlog_socket.c
+++ b/cbits/eventlog_socket.c
@@ -20,6 +20,10 @@
 #define LISTEN_BACKLOG 5
 #define POLL_TIMEOUT 10000
 
+#ifndef POLLRDHUP
+#define POLLRDHUP POLLHUP
+#endif
+
 // logging helper macros:
 // - use PRINT_ERR to unconditionally log erroneous situations
 // - otherwise use DEBUG_ERR


### PR DESCRIPTION
on my setup (nix on m1 macos), POLLRDHUP was not defined, but defining POLLRDHUP as POLLHUP enabled eventlog-socket to work.