### PR TITLE
Provide nix flake dev shell with ghc 9.4.4

### DIFF
--- a/cbits/eventlog_socket.c
+++ b/cbits/eventlog_socket.c
@@ -531,4 +531,3 @@ void eventlog_socket_start(const char *sock_path, bool wait)
     eventlog_socket_wait();
   }
 }
-

--- a/eventlog-socket.cabal
+++ b/eventlog-socket.cabal
@@ -23,7 +23,7 @@ library
   other-extensions: CApiFFI
 
   -- Use base lower bound as proxy for GHC >= 8.10
-  build-depends:    base >=4.14 && <4.17
+  build-depends:    base >=4.14 && <4.18
   hs-source-dirs:   src
   default-language: Haskell2010
   c-sources:        cbits/eventlog_socket.c
@@ -31,4 +31,4 @@ library
 
   -- comment me out while debugging
   -- https://github.com/haskell/cabal/issues/7635
-  cc-options:      -DNDEBUG=1
+  -- cc-options:      -DNDEBUG=1

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675285770,
+        "narHash": "sha256-m+AGZK4cgr4BuA+HVl4WUaWmFWaRvcKzYeWNiJzsaLE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "98cc33580fe34ffc1ffd3a6017619c58450bcfa0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "ghc-eventlog-socket";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachSystem flake-utils.lib.allSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      hsPkgs = pkgs.haskell.packages.ghc944;
+      hsenv = hsPkgs.ghcWithPackages (p: [ p.random ]);
+      shell = pkgs.mkShell {
+        buildInputs = [
+          hsenv
+          pkgs.alejandra # nix expression formatter
+          pkgs.cabal-install
+          pkgs.zlib
+        ];
+      };
+    in {
+      devShells.default = shell;
+    });
+}


### PR DESCRIPTION
This PR provides a dev shell with nix flake into which one can enter by `nix develop`. 
