### PR TITLE
Different polling interval for listen and log flushing

### DIFF
--- a/cbits/eventlog_socket.c
+++ b/cbits/eventlog_socket.c
@@ -18,7 +18,8 @@
 #include "eventlog_socket.h"
 
 #define LISTEN_BACKLOG 5
-#define POLL_TIMEOUT 10000
+#define POLL_LISTEN_TIMEOUT 10000
+#define POLL_WRITE_TIMEOUT 1000
 
 // logging helper macros:
 // - use PRINT_ERR to unconditionally log erroneous situations
@@ -252,7 +253,7 @@ static void listen_iteration() {
 
   // poll until we can accept
   while (true) {
-    int ret = poll(&pfd_accept, 1, POLL_TIMEOUT);
+    int ret = poll(&pfd_accept, 1, POLL_LISTEN_TIMEOUT);
     if (ret ==  -1) {
       PRINT_ERR("poll() failed: %s\n", strerror(errno));
       return;
@@ -312,7 +313,7 @@ static void nonwrite_iteration(int fd) {
     .revents = 0,
   };
 
-  int ret = poll(&pfd, 1, POLL_TIMEOUT);
+  int ret = poll(&pfd, 1, POLL_WRITE_TIMEOUT);
   if (ret == -1 && errno != EAGAIN) {
     // error
     PRINT_ERR("poll() failed: %s\n", strerror(errno));
@@ -356,7 +357,7 @@ static void write_iteration(int fd) {
     .revents = 0,
   };
 
-  int ret = poll(&pfd, 1, POLL_TIMEOUT);
+  int ret = poll(&pfd, 1, POLL_WRITE_TIMEOUT);
   if (ret == -1 && errno != EAGAIN) {
     // error
     PRINT_ERR("poll() failed: %s\n", strerror(errno));


### PR DESCRIPTION
POLL_TIMEOUT = 10 sec was indiscriminately applied for listening socket acceptance and writing logs out to the socket. I separate timeout to POLL_LISTEN_TIMEOUT = 10s and POLL_WRITE_TIMEOUT = 1s.
 