### PR TITLE
Fix warnings and errors on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+dist-newstyle
+.vscode
 cabal.project.local
 eventlog_socket.o

--- a/cbits/eventlog_socket.c
+++ b/cbits/eventlog_socket.c
@@ -20,6 +20,10 @@
 #define LISTEN_BACKLOG 5
 #define POLL_TIMEOUT 10000
 
+#ifndef POLLRDHUP
+#define POLLRDHUP 0x2000
+#endif
+
 // logging helper macros:
 // - use PRINT_ERR to unconditionally log erroneous situations
 // - otherwise use DEBUG_ERR
@@ -242,7 +246,7 @@ static void listen_iteration() {
   }
 
   struct sockaddr_un remote;
-  int len;
+  unsigned int len;
 
   struct pollfd pfd_accept = {
     .fd = listen_fd,


### PR DESCRIPTION
This makes it compile on Mac. I got the `POLLRDHUP` fix from [here](https://github.com/eddic/fastcgipp/issues/73). Also added some nice-to-have things to the `.gitignore`.