### PR TITLE
Add eventlog-socket lifecycle hooks.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,9 @@ The most important scripts are as follows:
     ./scripts/ttyd.sh './scripts/test.sh -- -p /test_oddball_Reconnect_Unix/'
     ```
 
-    > [!IMPORTANT]
-    > The command must be passed in quotes.
+    The command must be passed in quotes.
 
-    > [!NOTE]
-    > The name stands for "try 'til you die".
+    > ℹ️ The name stands for "try 'til you die".
 
 ## Naming Convention for C Functions
 
@@ -139,8 +137,7 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
     git tag eventlog-socket-${VERSION}
     ```
 
-    > [!CAUTION]
-    > Replace `${VERSION}` with the new version.
+    > ⚠️ Replace `${VERSION}` with the new version.
 
 3.  Publish the Git tag:
     ```sh
@@ -163,11 +160,9 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
       + [`eventlog-socket-tests`](https://github.com/well-typed/eventlog-socket/tree/eventlog-socket-${VERSION}/eventlog-socket-tests/)
       ```
 
-      > [!CAUTION]
-      > Replace `${VERSION}` with the new version.
+      > ⚠️ Replace `${VERSION}` with the new version.
 
-    > [!CAUTION]
-    > Do not commit these changes.
+    > ⚠️ Do not commit these changes.
 
 5.  Build the source distribution.
 
@@ -175,8 +170,7 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
     cabal sdist eventlog-socket
     ```
 
-    > [!TIP]
-    > This writes the source distribution to `dist-newstyle/sdist/eventlog-socket-${VERSION}.tar.gz`.
+    > ℹ️ This writes the source distribution to `dist-newstyle/sdist/eventlog-socket-${VERSION}.tar.gz`.
 
 6.  Upload the source distribution to Hackage *as a package candidate*
 
@@ -193,23 +187,20 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
     ./scripts/build-haddock.sh
     ```
 
-    > [!TIP]
-    > This writes the documentation to `dist-newstyle/eventlog-socket-${VERSION}-docs.tar.gz`.
+    > ℹ️ This writes the documentation to `dist-newstyle/eventlog-socket-${VERSION}-docs.tar.gz`.
 
 10. Upload the Haddock documentation *to the package candidate page*.
 
     - On the package candidate package, click on *"edit package information"*.
     - Under *"Manage Documentation"*, click on the candidate version *"eventlog-socket-${VERSION}"*.
 
-      > [!CAUTION]
-      > Replace `${VERSION}` with the new version.
+      > ⚠️ Replace `${VERSION}` with the new version.
 
     - Upload the documentation built in the previous step.
 
 11. Ensure that the documentation for the Haskell modules has no errors.
 
-    > [!WARNING]
-    > Since package candidates are published at different URLs, the link to the Doxygen documentation is broken for package candidates.
+    > ⚠️ Since package candidates are published at different URLs, the link to the Doxygen documentation is broken for package candidates.
 
 12. Publish the candidate package.
 
@@ -232,8 +223,7 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
     git tag eventlog-socket-control-${VERSION}
     ```
 
-    > [!CAUTION]
-    > Replace `${VERSION}` with the new version.
+    > ⚠️ Replace `${VERSION}` with the new version.
 
 3.  Publish the Git tag:
     ```sh
@@ -246,8 +236,7 @@ The process for making a well-documented release of `eventlog-socket` is a bit t
     cabal sdist eventlog-socket-control
     ```
 
-    > [!TIP]
-    > This writes the source distribution to `dist-newstyle/sdist/eventlog-socket-control-${VERSION}.tar.gz`.
+    > ℹ️ This writes the source distribution to `dist-newstyle/sdist/eventlog-socket-control-${VERSION}.tar.gz`.
 
 6.  Upload the source distribution to Hackage *as a package candidate*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,32 @@ The most important scripts are as follows:
 
     This script runs all tests for `eventlog-socket` and `eventlog-socket-control`.
 
+    The script runs the test suite and passes any parameters before `--` on to Cabal and after `--` to the Tasty test runner.
+    For instance, to run only `test_fibber_Unix`, run:
+
+    ```sh
+    ./scripts/test.sh -- -p /test_fibber_Unix/
+    ```
+
+    By default, the tests are linked against a version of `eventlog-socket` compiled with `-f+debug`.
+    You can control the debug verbosity by passing one of the `-f+debug-verbosity-X` flags.
+    You can control whether or not all received events are logged using the `-f+debug-events` flag.
+    For instance, to run the test suite with `TRACE` verbosity and events, run:
+
+    ```sh
+    ./scripts/test.sh -f+debug-verbosity-trace -f+debug-events --
+    ```
+
+    By default, the script prints the test suite overview to stdout and writes a detailed test log to `eventlog-socket-tests.err.log`.
+    If the `DEBUG` environment variable is defined, the script prints the detailed test log, and writes the test suite overview *and* the detailed test log to `eventlog-socket-tests.out.log` and `eventlog-socket-tests.err.log`, respectively.
+
+    The Tasty suite runs tests concurrently, which means the detailed test log contains the interleaved output of multiple tests.
+    It can be helpful to run the test suite with `-j1` to ensure that all tests are run sequentially:
+
+    ```sh
+    ./scripts/test.sh -- -j1
+    ```
+
 -   <a name="scripts-lint-nm"></a>`./scripts/lint-nm.sh`
 
     This script builds the `eventlog-socket` library and checks that all exposed symbols follow [the naming convention](#naming-convention-for-c-functions).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,55 @@ To enable the eventlog, you must pass the `-l` RTS option. This can be done eith
   ./my-app +RTS -l -RTS
   ```
 
+## Lifecycle Hooks
+
+Every time a new client connects, the GHC RTS resends the eventlog header and initialisation events.
+If you develop a package that communicates over the eventlog, you may find that your package *also* needs to resent certain initialisation events.
+The `eventlog-socket` package provides lifecycle hooks for this purpose.
+There are two supported hooks:
+
+1. The *post-startEventLogging* hook triggers *after* each time event logging is started.
+2. The *pre-endEventLogging* hook triggers *before* each time event logging is ended.
+
+To register a handler for lifecycle hook, use the `registerHook` function.
+For instance, the following snippet registers a hook that sends a user message event every time event logging is started.
+
+```haskell
+module Main where
+
+import Data.Foldable (for_)
+import Debug.Trace (traceEventIO)
+import GHC.Eventlog.Socket (Hook (..), registerHook, start)
+import System.Environment (lookupEnv)
+
+main :: IO ()
+main = do
+  -- Register the greeting hook:
+  registerHook HookPostStartEventLogging $
+    traceEventIO "Hello, new user!"
+
+  -- Start eventlog-socket on GHC_EVENTLOG_UNIX_PATH, if set:
+  maybeUnixPath <- lookupEnv "GHC_EVENTLOG_UNIX_PATH"
+  for_ maybeUnixPath $ \unixPath -> do
+    putStrLn "Start eventlog-socket on " <> unixPath
+    start unixPath
+
+  -- The rest of your application:
+  ...
+```
+
+> [!CAUTION]
+> To avoid races, it is important that lifecycle hooks are registered *before* `eventlog-socket` is started.
+
+> [!NOTE]
+> The post-startEventLogging and pre-endEventLogging lifecycle hooks usually correspond to clients connecting and disconnecting, respectively.
+> The only exception is if your application is instrumented from a C main, in which case the *first* post-startEventLogging hook triggers immediately after the GHC RTS is initialised.
+> In this scenario, the first client *does not* trigger the post-startEventLogging hook, but subsequent clients *do*.
+
+For an example of an application that registers lifecycle hooks using the Haskell API, see [`examples/fibber`](examples/fibber/).
+
+For an example of an application that registers lifecycle hooks using the C API, see [`examples/fibber-c-main`](examples/fibber-c-main/).
+
 ## Control Commands
 
 When compiled with the `+control` feature flag, the eventlog socket supports *control commands*. These are messages that can be *written to* the eventlog socket by the client to control the RTS or execute custom control commands.

--- a/README.md
+++ b/README.md
@@ -184,110 +184,42 @@ Registration is a two-step process:
 1.  Register a namespace. This must be a string of between 1 and 255 bytes. By convention, this should be your Haskell package name.
 2.  Register each command. This must be a number between 1 and 255. By convention, this should be the first non-zero number that's still available for this namespace.
 
-Commands can be passed some user data at registration time. This is intended to let you defines multiple different commands using the same handler.
-
-For an example of an application instrumented with custom control commands using the Haskell API, see [`examples/custom-command`](examples/custom-command/).
-
-For an example of an application instrumented with custom control commands using the C API, see [`examples/custom-command-c-main`](examples/custom-command-c-main/).
-
-The following snippet defines the `registerGreeters` function, which registers two commands via the Haskell API:
+To register a namespace, use the `registerNamespace` function.
+To register a custom command handler, use the `registerCommand` function.
+For instance, the following snippet registers two custom commands under the `"greeters"` namespace which greet C and Haskell, respectively.
 
 ```haskell
-import GHC.Eventlog.Socket
+module Main where
+
+import Data.Foldable (for_)
+import Debug.Trace (traceEventIO)
+import GHC.Eventlog.Socket (Hook (..), registerHook, start)
+import System.Environment (lookupEnv)
 
 greeter :: String -> IO ()
 greeter name =
   putStrLn $ "Hello, " <> name <> "!"
 
-registerGreeters :: IO ()
-registerGreeters = do
+main :: IO ()
+main = do
+  -- Register the custom command handlers:
   myNamespace <- registerNamespace "greeters"
   registerCommand myNamespace (CommandId 1) (greeter "C")
   registerCommand myNamespace (CommandId 2) (greeter "Haskell")
+
+  -- Start eventlog-socket on GHC_EVENTLOG_UNIX_PATH, if set:
+  maybeUnixPath <- lookupEnv "GHC_EVENTLOG_UNIX_PATH"
+  for_ maybeUnixPath $ \unixPath -> do
+    putStrLn "Start eventlog-socket on " <> unixPath
+    start unixPath
+
+  -- The rest of your application:
+  ...
 ```
 
-The following snippet defines the `register_greeters` function, which registers two equivalent commands via the C API:
+> [!CAUTION]
+> To avoid races, it is important that custom commands are registered *before* `eventlog-socket` is started.
 
-```c
-#include <stdio.h>
-#include <stdlib.h>
-#include <eventlog_socket.h>
+For an example of an application instrumented with custom control commands using the Haskell API, see [`examples/custom-command`](examples/custom-command/).
 
-static void greeter(const EventlogSocketControlNamespace *const namespace,
-                       const EventlogSocketControlCommandId command_id,
-                       const void *user_data) {
-  (void) namespace;
-  (void) command_id;
-  printf("Hello, %s!", (const char*)user_data);
-}
-
-bool register_greeters(void) {
-  // Use the name of my Haskell package:
-  const char* const my_namespace = "my-app";
-
-  // Allocate space for the namespace object:
-  EventlogSocketControlNamespace *namespace = NULL;
-
-  // Try to register the namespace:
-  const EventlogSocketStatus namespace_status =
-    eventlog_socket_control_register_namespace(
-      strlen(my_namespace), my_namespace, &namespace);
-
-  // Handle any errors:
-  if (namespace_status.ess_status_code != EVENTLOG_SOCKET_OK) {
-    char *errmsg = eventlog_socket_strerror(namespace_status);
-    if (errmsg != NULL) {
-      fprintf(stderr, "ERROR: %s", errmsg);
-      free(errmsg);
-    }
-    return false;
-  }
-  // Otherwise, namespace contains a valid object.
-
-  // Use the first available non-zero command ID for greet_c:
-  const uint8_t greet_c_id = 1;
-
-  // Allocate data for the greet_c command, if needed:
-  static const char * const greet_c_data = "C";
-
-  // Try to register the greet_c command:
-  const EventlogSocketStatus greet_c_status =
-    eventlog_socket_control_register_command(
-      namespace, greet_c_id, greeter, greet_c_data);
-
-  // Handle any errors:
-  if (greet_c_status.ess_status_code != EVENTLOG_SOCKET_OK) {
-    char *errmsg = eventlog_socket_strerror(greet_c_status);
-    if (errmsg != NULL) {
-      fprintf(stderr, "ERROR: %s", errmsg);
-      free(errmsg);
-    }
-    return false;
-  }
-  // Otherwise, the command is registered.
-
-  // Use the next available command ID for greet_haskell:
-  const uint8_t greet_haskell_id = 2;
-
-  // Allocate data for the greet_haskell command, if needed:
-  static const char * const greet_haskell_data = "Haskell";
-
-  // Try to register the greet_haskell command:
-  const EventlogSocketStatus greet_haskell_status =
-    eventlog_socket_control_register_command(
-      namespace, greet_haskell_id, greeter, greet_haskell_data);
-
-  // Handle any errors:
-  if (greet_haskell_status.ess_status_code != EVENTLOG_SOCKET_OK) {
-    char *errmsg = eventlog_socket_strerror(greet_haskell_status);
-    if (errmsg != NULL) {
-      fprintf(stderr, "ERROR: %s", errmsg);
-      free(errmsg);
-    }
-    return false;
-  }
-  // Otherwise, the command is registered.
-
-  return true;
-}
-```
+For an example of an application instrumented with custom control commands using the C API, see [`examples/custom-command-c-main`](examples/custom-command-c-main/).

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -38,6 +38,7 @@ main = do
         , test_oddball_HasHeapProfSample
         , test_oddball_NoAutomaticHeapSamples
         , test_oddball_Reconnect
+        , test_oddball_HookOnReconnect
         , test_oddball_ResetOnReconnect
         , test_oddball_StartAndStopHeapProfiling
         , test_oddball_RequestHeapCensus
@@ -145,6 +146,28 @@ test_oddball_Reconnect =
             -- event (as proxy for the init events) and at least one heap profile sample.
             assertEventlogWith eventlogSocket $ hasWallClockTime &> hasHeapProfSampleString
             assertEventlogWith eventlogSocket $ hasWallClockTime &> hasHeapProfSampleString
+
+{- |
+Test that @oddball@ triggers the post-startEventLogging hook on reconnect.
+-}
+test_oddball_HookOnReconnect :: (HasLogger) => EventlogSocketAddr -> ProgramTest
+test_oddball_HookOnReconnect =
+    let oddball =
+            Program
+                { name = "oddball"
+                , args = []
+                , rtsopts = ["-l-au", "--eventlog-flush-interval=1"]
+                , eventlogSocketBuildFlags = []
+                }
+     in programTestFor "test_oddball_HookOnReconnect" oddball $ \eventlogSocket -> do
+            -- Validate that reconnecting works and that each stream has a WallClockTime
+            -- event (as proxy for the init events) and triggers the post-startEventLogging hook.
+            assertEventlogWith eventlogSocket $
+                hasWallClockTime
+                    &> hasMatchingUserMarker ("HookPostStartEventLogging" `T.isPrefixOf`)
+            assertEventlogWith eventlogSocket $
+                hasWallClockTime
+                    &> hasMatchingUserMarker ("HookPostStartEventLogging" `T.isPrefixOf`)
 
 {- |
 Test that the command parsing state is reset on reconnect.

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -27,12 +27,9 @@ main = do
         -- Create temporary directory:
         withTempDirectory "/tmp" "eventlog-socket" $ \tmpDir -> do
             -- Base socket addresses
-            let baseUnixSocket = EventlogSocketUnixAddr $ tmpDir </> "ghc_eventlog.sock"
-            let baseInetSocket = EventlogSocketInetAddr "127.0.0.1" tcpPort
-            defaultMain . testGroup "Tests" $
-                [ testGroup "With Unix socket:" . runProgramTests $ fmap ($ baseUnixSocket) tests
-                , testGroup "With Inet socket:" . runProgramTests $ fmap ($ baseInetSocket) tests
-                ]
+            let unixTests = tests <*> pure (EventlogSocketUnixAddr $ tmpDir </> "ghc_eventlog.sock")
+            let inetTests = tests <*> pure (EventlogSocketInetAddr "127.0.0.1" tcpPort)
+            defaultMain . testGroup "Tests" . runProgramTests $ unixTests <> inetTests
   where
     tests :: (HasLogger) => [EventlogSocketAddr -> ProgramTest]
     tests =

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -60,8 +60,10 @@ test_fibber =
                 }
      in programTestFor "test_fibber" fibber $ \eventlogSocket -> do
             assertEventlogWith eventlogSocket $
-                -- Validate that the Finished marker is seen.
-                hasMatchingUserMarker ("Finished" `T.isPrefixOf`)
+                -- Validate that the startEventLogging hook fires.
+                hasMatchingUserMarker ("HookPostStartEventLogging" `T.isPrefixOf`)
+                    -- Validate that the Finished marker is seen.
+                    &> hasMatchingUserMarker ("Finished" `T.isPrefixOf`)
 
 {- |
 Test that @fibber-c-main 35@ produces a parseable eventlog.
@@ -78,8 +80,10 @@ test_fibberCMain =
      in programTestFor "test_fibberCMain" fibberCMain $ \eventlogSocket -> do
             threadDelay 3_000_000
             assertEventlogWith eventlogSocket $
-                -- Validate that the Initialising marker is seen.
-                hasMatchingUserMarker ("Initialising" `T.isPrefixOf`)
+                -- Validate that the startEventLogging hook fires.
+                hasMatchingUserMarker ("HookPostStartEventLogging" `T.isPrefixOf`)
+                    -- Validate that the Initialising marker is seen.
+                    &> hasMatchingUserMarker ("Initialising" `T.isPrefixOf`)
                     -- Validate that the Starting marker is seen.
                     &> hasMatchingUserMarker ("Starting" `T.isPrefixOf`)
                     -- Validate that the Finished marker is seen.

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -35,7 +35,7 @@ main = do
     tests =
         [ test_fibber
         , test_fibberCMain
-        , test_oddball
+        , test_oddball_HasHeapProfSample
         , test_oddball_NoAutomaticHeapSamples
         , test_oddball_Reconnect
         , test_oddball_ResetOnReconnect
@@ -88,8 +88,8 @@ test_fibberCMain =
 {- |
 Test that @oddball@ produces heap profile samples.
 -}
-test_oddball :: (HasLogger) => EventlogSocketAddr -> ProgramTest
-test_oddball =
+test_oddball_HasHeapProfSample :: (HasLogger) => EventlogSocketAddr -> ProgramTest
+test_oddball_HasHeapProfSample =
     let oddball =
             Program
                 { name = "oddball"
@@ -97,7 +97,7 @@ test_oddball =
                 , rtsopts = ["-l-au", "-hT", "-A256K", "-i0", "--eventlog-flush-interval=1"]
                 , eventlogSocketBuildFlags = []
                 }
-     in programTestFor "test_oddball" oddball $ \eventlogSocket -> do
+     in programTestFor "test_oddball_HasHeapProfSample" oddball $ \eventlogSocket -> do
             assertEventlogWith eventlogSocket $
                 -- Validate that the Summing marker is seen, and that the event
                 -- stream contains at least one heap profile sample.

--- a/eventlog-socket-tests/tests/Test/Common.hs
+++ b/eventlog-socket-tests/tests/Test/Common.hs
@@ -958,7 +958,8 @@ data TestInfo = TestInfo
     }
 
 data ProgramTest = ProgramTest
-    { programDesc :: ProgramDesc
+    { testInfo :: TestInfo
+    , programDesc :: ProgramDesc
     , makeProgram :: IO FilePath
     , freeProgram :: FilePath -> IO ()
     , testProgram :: IO FilePath -> TestTree
@@ -973,6 +974,7 @@ runProgramTests = fmap toTestGroup . groupByDesc
             & fmap (\pt -> M.singleton pt.programDesc (NE.singleton pt))
             & foldr (M.unionWith (<>)) M.empty
             & M.elems
+            & fmap (NE.sortBy (compare `on` (.testInfo.testName)))
 
     toTestGroup :: NonEmpty ProgramTest -> TestTree
     toTestGroup (pt :| pts) =
@@ -996,7 +998,8 @@ programTestFor testBaseName program eventlogAssertion = \case
     EventlogSocketUnixAddr{..} -> do
         -- Create test info
         let testName = testBaseName <> "_Unix"
-        let ?testInfo = TestInfo{..}
+        let testInfo = TestInfo{..}
+        let ?testInfo = testInfo
 
         -- Create program resource
         let ProgramResource{..} = programResource program
@@ -1020,7 +1023,8 @@ programTestFor testBaseName program eventlogAssertion = \case
     EventlogSocketInetAddr{..} -> do
         -- Create test info
         let testName = testBaseName <> "_Inet"
-        let ?testInfo = TestInfo{..}
+        let testInfo = TestInfo{..}
+        let ?testInfo = testInfo
 
         -- Create program resource
         let ProgramResource{..} = programResource program

--- a/eventlog-socket-tests/tests/Test/Common.hs
+++ b/eventlog-socket-tests/tests/Test/Common.hs
@@ -196,6 +196,9 @@ programResource program = ProgramResource{..}
     -- Make the program binary
     makeProgram :: IO FilePath
     makeProgram = do
+        let ?testInfo = TestInfo{testName = "make_" <> programDesc}
+        debug Header
+
         ghc <- fromMaybe "ghc" <$> lookupEnv "GHC"
         cabal <- fromMaybe "cabal" <$> lookupEnv "CABAL"
 
@@ -217,13 +220,19 @@ programResource program = ProgramResource{..}
             debugFail . unlines $ ["Failed to find binary for program ", findOut, findErr]
             throwIO findExit
         let maybeProgramBin = fmap fst . L.uncons . lines $ findOut
-        flip (`maybe` pure) maybeProgramBin $ do
+        programBin <- flip (`maybe` pure) maybeProgramBin $ do
             debugFail . unlines $ ["Failed to find binary for program ", findOut, findErr]
             throwIO findExit
+
+        debug Footer
+        pure programBin
 
     -- Free the program binary
     freeProgram :: FilePath -> IO ()
     freeProgram _programBin = do
+        let ?testInfo = TestInfo{testName = "free_" <> programDesc}
+        debug Header
+
         cabal <- fromMaybe "cabal" <$> lookupEnv "CABAL"
 
         -- Clean up the build directory
@@ -235,11 +244,13 @@ programResource program = ProgramResource{..}
             debugFail . unlines $ ["Failed to find binary for program ", findOut, findErr]
             throwIO findExit
 
+        debug Footer
+
     -- Fork the program binary
     forkProgram :: FilePath -> EventlogSocketAddr -> IO ProgramHandle
     forkProgram programBin eventlogSocketAddr = do
         -- Start program
-        debugInfo $ "Launching program " <> program.name
+        debugInfo $ "Launching program " <> programDesc
         inheritedEnv <- filter shouldInherit <$> getEnvironment
         let programArgs = program.args <> ["+RTS"] <> program.rtsopts <> ["-RTS"]
         let extraEnv = eventlogSocketEnv eventlogSocketAddr
@@ -263,7 +274,7 @@ programResource program = ProgramResource{..}
         programPid <- programPidIO
         let info = ProgramInfo{..}
         let ?programInfo = info
-        debugInfo $ "Launched"
+        debugInfo $ "Launched " <> programDesc
         -- Start loggers for stderr and stdout:
         maybeKillDebugOut <- traverse (debugHandle $ ProgramOut info) maybeHandleOut
         maybeKillDebugErr <- traverse (debugHandle $ ProgramErr info) maybeHandleErr
@@ -993,6 +1004,7 @@ programTestFor testBaseName program eventlogAssertion = \case
         -- Create program test
         let testProgram findProgram = do
                 testCase testName $ do
+                    debug Header
                     -- Update the eventlog socket to avoid conflicts
                     let (directory, fileName) = splitFileName esaUnixPath
                     let unixPath' = directory </> testName <> "_" <> fileName
@@ -1001,10 +1013,9 @@ programTestFor testBaseName program eventlogAssertion = \case
                     programBin <- findProgram
                     withProgram programBin eventlogSocketAddr $ do
                         -- The the eventlog assertion
-                        debug Header
                         debugInfo $ "Using Unix socket: " <> unixPath'
                         eventlogAssertion eventlogSocketAddr
-                        debug Footer
+                    debug Footer
         ProgramTest{..}
     EventlogSocketInetAddr{..} -> do
         -- Create test info
@@ -1095,7 +1106,7 @@ withLogger action = do
         Header ->
             "-- HEADER: " <> testName <> " " <> replicate (80 - (length testName + 12)) '-'
         Footer ->
-            "-- FOOTER: " <> testName <> " " <> replicate (80 - (length testName + 12)) '-'
+            "-- FOOTER: " <> testName <> " " <> replicate (80 - (length testName + 12)) '-' <> "\n"
         ProgramOut info message ->
             "[" <> testName <> ", " <> prettyProgramInfo info <> "] stdout: " <> message
         ProgramErr info message ->

--- a/eventlog-socket/CHANGELOG.md
+++ b/eventlog-socket/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Revision history for eventlog-socket
 
+## 0.1.3.0 -- 2026-03-27
+
+- Add support for hooks that fire at certain points in the `eventlog-socket` lifecycle.
+
+  This adds `registerHook` and `eventlog_socket_register_hook` to the Haskell and C APIs, respectively, as well as two kinds of hooks:
+  - A _post-startEventLogging_ hook, which is triggered whenever event logging is started.
+  - A _pre-endEventLogging_ hook, which is triggered whenever event logging is ended.
+
+  These hooks are intended to give package writers the ability to add their own init events, which are resent event time that a new client connects. For instance, the following code registers a post-startEventLogging hook that greets every new client with a user message event:
+
+  ```haskell
+  registerHook HookPostStartEventLogging $
+    traceEventIO "Hello, new user!"
+  ```
+
+  To avoid races, it is important that these hooks are registered *before* `eventlog-socket` is started.
+
 ## 0.1.2.0 -- 2026-03-25
 
 **Warning**: The C API exposed from this version contains breaking changes over the C API exposed from version 0.1.1.0. This is justified by the fact that the C API exposed from version 0.1.1.0 is broken and that version is deprecated and not known to be in use.

--- a/eventlog-socket/cbits/eventlog_socket.c
+++ b/eventlog-socket/cbits/eventlog_socket.c
@@ -22,6 +22,7 @@
 
 #include "./eventlog_socket/debug.h"
 #include "./eventlog_socket/error.h"
+#include "./eventlog_socket/hooks.h"
 #include "./eventlog_socket/init_state.h"
 #include "./eventlog_socket/string.h"
 #include "./eventlog_socket/worker.h"
@@ -340,6 +341,14 @@ EventlogSocketStatus eventlog_socket_signal_ghc_rts_ready(void) {
   RETURN_ON_ERROR(STATUS_FROM_PTHREAD(pthread_mutex_lock(&g_mutex)));
   // If the RTS is not marked as ready...
   if (!(g_init_state & EVENTLOG_SOCKET_SIG_RTS_READY)) {
+    // If EventLogSocketWriter is already attached...
+    if (g_init_state & EVENTLOG_SOCKET_SIG_ATTACHED) {
+      // ...trigger the post-startEventLogging hooks.
+      DEBUG_DEBUG("%s", "Trigger post-startEventLogging hooks.");
+      RETURN_ON_ERROR_CLEANUP(
+          es_hooks_handle_hook(EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING),
+          pthread_mutex_unlock(&g_mutex));
+    }
     // ...broadcast on the relevant condition and...
     RETURN_ON_ERROR_CLEANUP(
         STATUS_FROM_PTHREAD(pthread_cond_broadcast(&g_ghc_rts_ready_cond)),
@@ -627,4 +636,12 @@ EventlogSocketStatus eventlog_socket_control_status(void) {
 #else
   return STATUS_FROM_CODE(EVENTLOG_SOCKET_OK);
 #endif /* EVENTLOG_SOCKET_FEATURE_CONTROL */
+}
+
+/* PUBLIC - see documentation in eventlog_socket.h */
+EventlogSocketStatus
+eventlog_socket_register_hook(EventlogSocketHook hook,
+                              EventlogSocketHookHandler *hook_handler,
+                              const void *hook_data) {
+  return es_hooks_register_hook(hook, hook_handler, hook_data);
 }

--- a/eventlog-socket/cbits/eventlog_socket/hooks.c
+++ b/eventlog-socket/cbits/eventlog_socket/hooks.c
@@ -1,0 +1,149 @@
+#include <string.h>
+
+#include "./error.h"
+#include "./hooks.h"
+#include "eventlog_socket.h"
+
+/******************************************************************************
+ * Hook Handler Registry
+ ******************************************************************************/
+
+/// @brief An entry in the hook registry.
+typedef struct EventlogSocketHookHandlerEntry EventlogSocketHookHandlerEntry;
+
+/// @brief An entry in the handler registry for one particular hook.
+struct EventlogSocketHookHandlerEntry {
+  /// @brief The user-provided hook handler.
+  EventlogSocketHookHandler *const hook_handler;
+  /// @brief The user-provided data for the hook handler.
+  const void *hook_data;
+  /// @brief The pointer to the next entry in the hook registry.
+  EventlogSocketHookHandlerEntry *next;
+};
+
+/// @brief The registry for all hooks.
+typedef struct {
+  EventlogSocketHookHandlerEntry *on_connect_handlers;
+  EventlogSocketHookHandlerEntry *on_disconnect_handlers;
+} EventlogSocketHookHandlerRegistry;
+
+/// @brief The global hook handler registry.
+static EventlogSocketHookHandlerRegistry g_hook_handler_registry = {
+    .on_connect_handlers = NULL,
+    .on_disconnect_handlers = NULL,
+};
+
+/// @brief The mutex that guards the global hook handler registry.
+static pthread_mutex_t g_hook_handler_registry_mutex =
+    PTHREAD_MUTEX_INITIALIZER;
+
+/* HIDDEN - see documentation in hooks.h */
+HIDDEN EventlogSocketStatus es_hooks_register_hook(
+    const EventlogSocketHook hook,
+    EventlogSocketHookHandler *const hook_handler, const void *hook_data) {
+  // Validate the arguments.
+  if (hook_handler == NULL) {
+    errno = EINVAL;
+    return STATUS_FROM_ERRNO();
+  }
+
+  // Acquire the `g_hook_handler_registry_mutex`.
+  RETURN_ON_ERROR(
+      STATUS_FROM_PTHREAD(pthread_mutex_lock(&g_hook_handler_registry_mutex)));
+
+  // Get a pointer to the *first* entry for the given hook.
+  EventlogSocketHookHandlerEntry **entry = NULL;
+  switch (hook) {
+  case EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING:
+    entry = &g_hook_handler_registry.on_connect_handlers;
+    break;
+  case EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING:
+    entry = &g_hook_handler_registry.on_disconnect_handlers;
+    break;
+  default:
+    errno = EINVAL;
+    return STATUS_FROM_ERRNO();
+  }
+  if (entry == NULL) {
+    errno = EINVAL;
+    return STATUS_FROM_ERRNO();
+  }
+
+  // Get a pointer to the *last* entry for the given hook.
+  assert(entry != NULL);
+  while (*entry != NULL) {
+    // TODO: Check if the hook is already registered?
+    entry = &(*entry)->next;
+    assert(entry != NULL);
+  }
+
+  // Allocate memory and write the new hook handler and data.
+  assert(*entry == NULL);
+  *entry = malloc(sizeof(EventlogSocketHookHandlerEntry));
+  if (*entry == NULL) {
+    RETURN_ON_ERROR_CLEANUP(
+        STATUS_FROM_ERRNO(), // `malloc` sets errno.
+        pthread_mutex_unlock(&g_hook_handler_registry_mutex));
+  }
+  assert(*entry != NULL);
+  const EventlogSocketHookHandlerEntry hook_handler_entry =
+      (EventlogSocketHookHandlerEntry){
+          .hook_handler = hook_handler,
+          .hook_data = hook_data,
+          .next = NULL,
+      };
+  memcpy(*entry, &hook_handler_entry, sizeof(EventlogSocketHookHandlerEntry));
+
+  // Release the `g_hook_handler_registry_mutex`.
+  RETURN_ON_ERROR(STATUS_FROM_PTHREAD(
+      pthread_mutex_unlock(&g_hook_handler_registry_mutex)));
+
+  // Return OK.
+  return STATUS_FROM_CODE(EVENTLOG_SOCKET_OK);
+}
+
+/* HIDDEN - see documentation in hooks.h */
+HIDDEN EventlogSocketStatus
+es_hooks_handle_hook(const EventlogSocketHook hook) {
+
+  // Acquire the `g_hook_handler_registry_mutex`.
+  RETURN_ON_ERROR(
+      STATUS_FROM_PTHREAD(pthread_mutex_lock(&g_hook_handler_registry_mutex)));
+
+  // Get a pointer to the *first* entry for the given hook.
+  EventlogSocketHookHandlerEntry **entry = NULL;
+  switch (hook) {
+  case EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING:
+    entry = &g_hook_handler_registry.on_connect_handlers;
+    break;
+  case EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING:
+    entry = &g_hook_handler_registry.on_disconnect_handlers;
+    break;
+  default:
+    errno = EINVAL;
+    return STATUS_FROM_ERRNO();
+  }
+  if (entry == NULL) {
+    errno = EINVAL;
+    return STATUS_FROM_ERRNO();
+  }
+
+  // Loop through and call each hook handler.
+  assert(entry != NULL);
+  while (*entry != NULL) {
+    EventlogSocketHookHandler *const hook_handler = (*entry)->hook_handler;
+    if (hook_handler != NULL) {
+      const void *hook_data = (*entry)->hook_data;
+      hook_handler(hook_data);
+    }
+    entry = &(*entry)->next;
+    assert(entry != NULL);
+  }
+
+  // Release the `g_hook_handler_registry_mutex`.
+  RETURN_ON_ERROR(STATUS_FROM_PTHREAD(
+      pthread_mutex_unlock(&g_hook_handler_registry_mutex)));
+
+  // Return OK.
+  return STATUS_FROM_CODE(EVENTLOG_SOCKET_OK);
+}

--- a/eventlog-socket/cbits/eventlog_socket/hooks.h
+++ b/eventlog-socket/cbits/eventlog_socket/hooks.h
@@ -1,0 +1,17 @@
+#ifndef EVENTLOG_SOCKET_HOOKS_H
+#define EVENTLOG_SOCKET_HOOKS_H
+
+#include "./macros.h"
+#include "eventlog_socket.h"
+
+/// @brief Register a new hook handler.
+///
+/// @see eventlog_socket_register_hook
+HIDDEN EventlogSocketStatus es_hooks_register_hook(
+    EventlogSocketHook hook, EventlogSocketHookHandler *hook_handler,
+    const void *hook_data);
+
+/// @brief Call all handlers for a given `EventlogSocketHook`.
+HIDDEN EventlogSocketStatus es_hooks_handle_hook(EventlogSocketHook hook);
+
+#endif /* EVENTLOG_SOCKET_HOOKS_H */

--- a/eventlog-socket/cbits/eventlog_socket/worker.c
+++ b/eventlog-socket/cbits/eventlog_socket/worker.c
@@ -16,11 +16,16 @@
 
 #include "./debug.h"
 #include "./error.h"
+#include "./hooks.h"
 #include "./init_state.h"
 #include "./poll.h"
 #include "./string.h"
 #include "./worker.h"
 #include "eventlog_socket.h"
+
+/******************************************************************************
+ * Worker Thread
+ ******************************************************************************/
 
 /// @brief The maximum length of the queue for pending connections.
 #define LISTEN_BACKLOG 5
@@ -291,7 +296,7 @@ static void es_worker_step_listen(void) {
   const bool should_stop =
       // ...some eventlog writer is currently running and either:
       is_running && (
-                        // ...(1) it's not EventlogSocketWriter, or...
+                        // ...(1) it's not EventLogSocketWriter, or...
                         !is_attached ||
                         // ...(2) we've already had our first connection.
                         //
@@ -309,6 +314,13 @@ static void es_worker_step_listen(void) {
 
   // We stop event logging.
   if (should_stop) {
+    // If the current eventlog writer *is* EventLogSocketWriter...
+    if (is_attached) {
+      // ...trigger the pre-endEventLogging hooks.
+      DEBUG_DEBUG("%s", "Trigger pre-endEventLogging hooks.");
+      EXIT_ON_ERROR(
+          es_hooks_handle_hook(EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING));
+    }
     DEBUG_DEBUG("%s", "Stopping current event logger.");
     endEventLogging();
   }
@@ -325,9 +337,18 @@ static void es_worker_step_listen(void) {
   // We start event logging with EventlogSocketWriter.
   if (should_start) {
     DEBUG_DEBUG("%s", "Starting new event logger.");
-    // TODO: Add retry loop.
-    const bool is_started = startEventLogging(&EventLogSocketWriter);
+    bool is_started = false;
+    while (!is_started) {
+      // TODO: Limit number of retries. Since this loop should not be blocking,
+      //       this requires exiting this listen step and remembering that
+      //       connection was left in an unfinished state, and retrying
+      //       startEventLogging the next time a listen step is entered.
+      is_started = startEventLogging(&EventLogSocketWriter);
+    }
     DEBUG_TRACE("is_started: %s", is_started ? "true" : "false");
+    DEBUG_DEBUG("%s", "Trigger post-startEventLogging hooks.");
+    EXIT_ON_ERROR(
+        es_hooks_handle_hook(EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING));
   }
 
   // Update *g_worker_state.init_state_ptr to record that we've seen our first

--- a/eventlog-socket/eventlog-socket.cabal
+++ b/eventlog-socket/eventlog-socket.cabal
@@ -29,6 +29,8 @@ extra-source-files:
   cbits/eventlog_socket/debug.h
   cbits/eventlog_socket/error.c
   cbits/eventlog_socket/error.h
+  cbits/eventlog_socket/hooks.c
+  cbits/eventlog_socket/hooks.h
   cbits/eventlog_socket/init_state.h
   cbits/eventlog_socket/macros.h
   cbits/eventlog_socket/poll.h
@@ -98,6 +100,7 @@ library
   default-extensions: LambdaCase
   c-sources:
     cbits/eventlog_socket/error.c
+    cbits/eventlog_socket/hooks.c
     cbits/eventlog_socket/string.c
     cbits/eventlog_socket/worker.c
     cbits/eventlog_socket/write_buffer.c

--- a/eventlog-socket/include/eventlog_socket.h
+++ b/eventlog-socket/include/eventlog_socket.h
@@ -478,6 +478,47 @@ EventlogSocketStatus eventlog_socket_worker_status(void);
 EventlogSocketStatus eventlog_socket_control_status(void);
 
 /******************************************************************************
+ * Start/End Hooks
+ ******************************************************************************/
+
+/// @brief An @c eventlog-socket hook.
+typedef enum {
+  /// @brief The post-startEventLogging hook is guaranteed to be called *after*
+  /// each time that the `EventLogSocketWriter` is attached and event logging is
+  /// started.
+  ///
+  /// If the `EventLogSocketWriter` is attached in a C main, prior to GHC RTS
+  /// initialisation, then @c eventlog-socket waits to call this hook for the
+  /// first time until the GHC RTS is initialised.
+  EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING,
+  /// @brief The pre-endEventLogging hook is guaranteed to be called *before*
+  /// each time that the `EventLogSocketWriter` is detached and event logging is
+  /// ended.
+  EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING,
+} EventlogSocketHook;
+
+/// @brief An @c eventlog-socket hook handler.
+///
+/// @since 0.1.3.0
+typedef void EventlogSocketHookHandler(const void *hook_data);
+
+/// @brief Register a new hook handler.
+///
+/// @return Upon successful completion, this function registers the command and
+/// returns a status with code @c EVENTLOG_SOCKET_OK.
+///
+/// @return If a system error occurs, this function returns a status with code
+/// @c EVENTLOG_SOCKET_ERR_SYS and the error code set to indicate the error.
+///
+/// @note The @p hook_handler should not use the functions from this header.
+///
+/// @since 0.1.3.0
+EventlogSocketStatus
+eventlog_socket_register_hook(EventlogSocketHook hook,
+                              EventlogSocketHookHandler *hook_handler,
+                              const void *hook_data);
+
+/******************************************************************************
  * Control Commands
  ******************************************************************************/
 

--- a/eventlog-socket/src/GHC/Eventlog/Socket.hsc
+++ b/eventlog-socket/src/GHC/Eventlog/Socket.hsc
@@ -45,6 +45,14 @@ module GHC.Eventlog.Socket (
     fromEnv,
     EventlogSocketAddrError(..),
 
+    -- ** Hooks #hooks#
+    Hook (
+        HookPostStartEventLogging,
+        HookPreEndEventLogging
+    ),
+    HookHandler,
+    registerHook,
+
     -- ** Control commands #control_commands#
     Namespace,
     CommandId(..),
@@ -374,29 +382,35 @@ throwEventlogSocketStatus essPtr = do
 
 {- |
 The type of @eventlog-socket@ hooks.
+
+@since 0.1.3.0
 -}
 newtype
     {-# CTYPE "eventlog_socket.h" "EventlogSocketHook" #-}
-    EventlogSocketHook = EventlogSocketHook
-        { unEventlogSocketHook :: #{type EventlogSocketHook}
+    Hook = Hook
+        { unHook :: #{type EventlogSocketHook}
         }
         deriving (Eq, Show, Storable)
 
 {- |
-The hook for new connections.
+The hook that runs /after/ @startEventLogging@ is called.
+
+@since 0.1.3.0
 -}
-pattern EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING :: EventlogSocketTag
-pattern EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING = EventlogSocketTag #{const EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING}
+pattern HookPostStartEventLogging :: Hook
+pattern HookPostStartEventLogging = Hook #{const EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING}
 
 {- |
-The tag for a TCP/IP socket address.
+The hook that runs /before/ @endEventLogging@ is called.
+
+@since 0.1.3.0
 -}
-pattern EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING :: EventlogSocketTag
-pattern EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING = EventlogSocketTag #{const EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING}
+pattern HookPreEndEventLogging :: Hook
+pattern HookPreEndEventLogging = Hook #{const EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING}
 
 {-# COMPLETE
-    EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING,
-    EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING #-}
+    HookPostStartEventLogging,
+    HookPreEndEventLogging #-}
 
 {- |
 The type of hook handlers.
@@ -405,9 +419,54 @@ The hook handler is evaluated once each time the control socket receives a reque
 
 __Warning__: The hook handler /must not/ call back into the @eventlog-socket@ API.
 
-@since 0.1.2.0
+@since 0.1.3.0
 -}
 type HookHandler = IO ()
+
+{- |
+Register an @eventlog-socket@ hook.
+
+__Warning__: Hooks cannot be unregistered and will be kept in memory until program exit.
+
+@since 0.1.3.0
+-}
+registerHook ::
+    -- | The hook.
+    Hook ->
+    -- | The hook handler.
+    HookHandler ->
+    IO ()
+registerHook hook hookHandler = do
+    -- Wrap the Haskell hook handler for the C API
+    let c_hookHandler hookDataPtr =
+            assert (hookDataPtr == nullPtr) $
+            hookHandler
+
+    bracketOnError (makeHookHandlerFunPtr c_hookHandler) freeHaskellFunPtr $ \c_hookHandlerPtr -> do
+
+        -- Try to register the command:
+        status <-
+            -- Allocate space for the return status:
+            allocaBytes #{size EventlogSocketStatus} $ \essPtr -> do
+
+                -- Try to register the command:
+                eventlog_socket_register_hook
+                    essPtr
+                    hook
+                    c_hookHandlerPtr
+                    nullPtr
+
+                -- Marshal the return status:
+                peekEventlogSocketStatus essPtr
+
+        -- Handle the return status:
+        case essStatusCode status of
+            -- The return status is OK.
+            EVENTLOG_SOCKET_OK -> pure ()
+
+            -- The remaining errors are all system errors:
+            _otherwise ->
+                vacuous $ withEventlogSocketStatus status throwEventlogSocketStatus
 
 --------------------------------------------------------------------------------
 -- Control Commands API
@@ -1006,6 +1065,38 @@ foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_strerro
   )
   {
     return eventlog_socket_strerror(*eventlog_socket_status);
+  }
+}
+
+--------------------------------------------------------------------------------
+-- eventlog_socket_register_hook
+
+foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_register_hook"
+    eventlog_socket_register_hook ::
+        Ptr EventlogSocketStatus ->
+        Hook ->
+        FunPtr (Ptr a -> IO ()) ->
+        Ptr a ->
+        IO ()
+
+foreign import ccall "wrapper"
+    makeHookHandlerFunPtr ::
+        (Ptr a -> IO ()) ->
+        IO (FunPtr (Ptr a -> IO ()))
+
+#{def
+  HIDDEN void eventlog_socket_wrap_register_hook(
+    EventlogSocketStatus *eventlog_socket_status,
+    EventlogSocketHook eventlog_socket_hook,
+    EventlogSocketHookHandler eventlog_socket_hook_handler,
+    const void *eventlog_socket_hook_data
+  ) {
+    const EventlogSocketStatus status = eventlog_socket_register_hook(
+      eventlog_socket_hook,
+      eventlog_socket_hook_handler,
+      eventlog_socket_hook_data
+    );
+    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
   }
 }
 

--- a/eventlog-socket/src/GHC/Eventlog/Socket.hsc
+++ b/eventlog-socket/src/GHC/Eventlog/Socket.hsc
@@ -369,6 +369,47 @@ throwEventlogSocketStatus essPtr = do
     throwIO $ userError str
 
 --------------------------------------------------------------------------------
+-- Hooks API
+--------------------------------------------------------------------------------
+
+{- |
+The type of @eventlog-socket@ hooks.
+-}
+newtype
+    {-# CTYPE "eventlog_socket.h" "EventlogSocketHook" #-}
+    EventlogSocketHook = EventlogSocketHook
+        { unEventlogSocketHook :: #{type EventlogSocketHook}
+        }
+        deriving (Eq, Show, Storable)
+
+{- |
+The hook for new connections.
+-}
+pattern EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING :: EventlogSocketTag
+pattern EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING = EventlogSocketTag #{const EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING}
+
+{- |
+The tag for a TCP/IP socket address.
+-}
+pattern EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING :: EventlogSocketTag
+pattern EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING = EventlogSocketTag #{const EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING}
+
+{-# COMPLETE
+    EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING,
+    EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING #-}
+
+{- |
+The type of hook handlers.
+
+The hook handler is evaluated once each time the control socket receives a request for the associated hook.
+
+__Warning__: The hook handler /must not/ call back into the @eventlog-socket@ API.
+
+@since 0.1.2.0
+-}
+type HookHandler = IO ()
+
+--------------------------------------------------------------------------------
 -- Control Commands API
 --------------------------------------------------------------------------------
 

--- a/examples/fibber-c-main/cbits/fibber-c-main.c
+++ b/examples/fibber-c-main/cbits/fibber-c-main.c
@@ -5,10 +5,48 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define DEBUG_ERROR(fmt, ...)                                                  \
+  do {                                                                         \
+    fprintf(stderr, "ERROR[%s|%d|%s]: " fmt "\n", __FILE__, __LINE__,          \
+            __func__, __VA_ARGS__);                                            \
+  } while (0)
+
 // Get the main closure.
 extern StgClosure ZCMain_main_closure;
 
+/// Internal GHC function that writes a user marker to the eventlog.
+extern void traceUserMarker(Capability *cap, char *msg);
+
+/// Write a user marker to the eventlog.
+static void write_user_marker(char *const marker) {
+  Capability *cap = rts_lock();
+  if (cap == NULL) {
+    DEBUG_ERROR("%s", "could not acquire GHC RTS capability lock");
+    return;
+  }
+  traceUserMarker(cap, marker);
+  rts_unlock(cap);
+}
+
+// Hook for startEventLogging.
+void handler_HookPostStartEventLogging(const void *arg) {
+  (void)arg;
+  write_user_marker("HookPostStartEventLogging fired.");
+}
+
+// Hook for endEventLogging.
+void handler_HookPreEndEventLogging(const void *arg) {
+  (void)arg;
+  write_user_marker("HookPreEndEventLogging fired.");
+}
+
 int main(int argc, char *argv[]) {
+
+  // Register start/end hooks.
+  eventlog_socket_register_hook(EVENTLOG_SOCKET_HOOK_POST_START_EVENT_LOGGING,
+                                &handler_HookPostStartEventLogging, NULL);
+  eventlog_socket_register_hook(EVENTLOG_SOCKET_HOOK_PRE_END_EVENT_LOGGING,
+                                &handler_HookPreEndEventLogging, NULL);
 
   // Create a GHC RTS configuration object.
   RtsConfig rts_config = {0};

--- a/examples/fibber/app/Main.hs
+++ b/examples/fibber/app/Main.hs
@@ -6,7 +6,7 @@ import Control.Monad (forever)
 import Data.Foldable (for_, traverse_)
 import Data.Maybe (fromMaybe)
 import Debug.Trace (flushEventLog, traceMarkerIO)
-import GHC.Eventlog.Socket (startFromEnv, testControlStatus, testWorkerStatus)
+import GHC.Eventlog.Socket (Hook (..), registerHook, startFromEnv, testControlStatus, testWorkerStatus)
 import System.Environment (getArgs, lookupEnv)
 
 #if MIN_VERSION_base(4,20,0)
@@ -30,7 +30,14 @@ performPreferablyBlockingMajorGC = performMajorGC
 
 main :: IO ()
 main = do
+    -- Register hooks:
+    registerHook HookPostStartEventLogging $
+        traceMarkerIO "HookPostStartEventLogging fired."
+    registerHook HookPreEndEventLogging $
+        traceMarkerIO "HookPreEndEventLogging fired."
+    -- Start eventlog-socket:
     startFromEnv
+    -- Start fibber:
     args <- getArgs
     let (mode, fibArgs) = parseArgs args
         workload = for_ fibArgs $ \arg -> do

--- a/examples/oddball/app/Main.hs
+++ b/examples/oddball/app/Main.hs
@@ -6,12 +6,20 @@ import Data.Maybe
 import Debug.Trace
 import GHC.Eventlog.Socket
 import System.Environment
+import System.IO (hPutStrLn, stderr)
 import System.Mem (performMajorGC)
 import System.Random
 
 main :: IO ()
 main = do
+    -- Register hooks:
+    registerHook HookPostStartEventLogging $
+        traceMarkerIO "HookPostStartEventLogging fired."
+    registerHook HookPreEndEventLogging $
+        hPutStrLn stderr "HookPreEndEventLogging fired."
+    -- Start eventlog-socket:
     startFromEnv
+    -- Start oddball:
     _ <- forever $ threadDelay 3000000 >> doRandom
     pure ()
 


### PR DESCRIPTION
This PR adds support for hooks that fire at certain points in the `eventlog-socket` lifecycle.

This adds `registerHook` and `eventlog_socket_register_hook` to the Haskell and C APIs, respectively, as well as two kinds of hooks:
- A _post-startEventLogging_ hook, which is triggered whenever event logging is started.
- A _pre-endEventLogging_ hook, which is triggered whenever event logging is ended.

These hooks are intended to give package writers the ability to add their own init events, which are resent event time that a new client connects. For instance, the following code registers a post-startEventLogging hook that greets every new client with a user message event:

```haskell
registerHook HookPostStartEventLogging $
  traceEventIO "Hello, new user!"
```

To avoid races, it is important that these hooks are registered *before* `eventlog-socket` is started.

---

This PR also contains fixes for the test suite (the Unix and Inet tests race for building the tested program) and updates the documentation (CONTRIBUTING.md, CHANGELOG.md, README.md) including for areas that are not directly related to the contributions in this PR.