### PR TITLE
Support building with hsc2hs in cross-compilation mode.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,5 @@ packages: examples/custom-command-c-main/custom-command-c-main.cabal
 packages: examples/fibber/fibber.cabal
 packages: examples/fibber-c-main/fibber-c-main.cabal
 packages: examples/oddball/oddball.cabal
+
+import: cabal.project.config

--- a/cabal.project.config
+++ b/cabal.project.config
@@ -1,0 +1,3 @@
+-- Build with hsc2hs in cross-compilation mode:
+program-options
+  hsc2hs-options: -x

--- a/eventlog-socket/cbits/eventlog_socket/hsapi.c
+++ b/eventlog-socket/cbits/eventlog_socket/hsapi.c
@@ -1,0 +1,84 @@
+/// @file      hsapi.c
+/// @brief     Helper functions for the @c GHC.Eventlog.Socket module.
+/// @details   This module defines wrappers for some of the functions
+///            exported by @c eventlog_socket.h for use in the Haskell
+///            module @c GHC.Eventlog.Socket.
+/// @author    Wen Kokke
+/// @version   0.1.2.1
+/// @date      2025-2026
+/// @copyright BSD-3-Clause License.
+///
+
+#include "./hsapi.h"
+#include <string.h>
+
+HIDDEN void es_hsapi_start(EventlogSocketStatus *eventlog_socket_status,
+                           EventlogSocketAddr *eventlog_socket_addr,
+                           EventlogSocketOpts *eventlog_socket_opts) {
+  const EventlogSocketStatus status =
+      eventlog_socket_start(eventlog_socket_addr, eventlog_socket_opts);
+  memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
+}
+
+HIDDEN void es_hsapi_from_env(EventlogSocketStatus *eventlog_socket_status,
+                              EventlogSocketAddr *eventlog_socket_addr,
+                              EventlogSocketOpts *eventlog_socket_opts) {
+  const EventlogSocketStatus status =
+      eventlog_socket_from_env(eventlog_socket_addr, eventlog_socket_opts);
+  memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
+}
+
+HIDDEN char *es_hsapi_strerror(EventlogSocketStatus *eventlog_socket_status) {
+  return eventlog_socket_strerror(*eventlog_socket_status);
+}
+
+HIDDEN void
+es_hsapi_register_hook(EventlogSocketStatus *eventlog_socket_status,
+                       EventlogSocketHook eventlog_socket_hook,
+                       EventlogSocketHookHandler eventlog_socket_hook_handler,
+                       const void *eventlog_socket_hook_data) {
+  const EventlogSocketStatus status = eventlog_socket_register_hook(
+      eventlog_socket_hook, eventlog_socket_hook_handler,
+      eventlog_socket_hook_data);
+  memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
+}
+
+HIDDEN void
+es_hsapi_worker_status(EventlogSocketStatus *eventlog_socket_status_out) {
+  const EventlogSocketStatus eventlog_socket_status =
+      eventlog_socket_worker_status();
+  memcpy(eventlog_socket_status_out, &eventlog_socket_status,
+         sizeof(EventlogSocketStatus));
+}
+
+HIDDEN void
+es_hsapi_control_status(EventlogSocketStatus *eventlog_socket_status_out) {
+  const EventlogSocketStatus eventlog_socket_status =
+      eventlog_socket_control_status();
+  memcpy(eventlog_socket_status_out, &eventlog_socket_status,
+         sizeof(EventlogSocketStatus));
+}
+
+HIDDEN void es_hsapi_control_register_namespace(
+    EventlogSocketStatus *eventlog_socket_status,
+    uint8_t eventlog_socket_namespace_len,
+    char eventlog_socket_namespace[eventlog_socket_namespace_len],
+    EventlogSocketControlNamespace **eventlog_socket_namespace_out) {
+  const EventlogSocketStatus status =
+      eventlog_socket_control_register_namespace(eventlog_socket_namespace_len,
+                                                 eventlog_socket_namespace,
+                                                 eventlog_socket_namespace_out);
+  memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
+}
+
+HIDDEN void es_hsapi_control_register_command(
+    EventlogSocketStatus *eventlog_socket_status,
+    EventlogSocketControlNamespace *eventlog_socket_namespace,
+    EventlogSocketControlCommandId eventlog_socket_command_id,
+    EventlogSocketControlCommandHandler eventlog_socket_command_handler,
+    const void *eventlog_socket_command_data) {
+  const EventlogSocketStatus status = eventlog_socket_control_register_command(
+      eventlog_socket_namespace, eventlog_socket_command_id,
+      eventlog_socket_command_handler, eventlog_socket_command_data);
+  memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
+}

--- a/eventlog-socket/cbits/eventlog_socket/hsapi.h
+++ b/eventlog-socket/cbits/eventlog_socket/hsapi.h
@@ -1,0 +1,48 @@
+/// @file      hsapi.h
+/// @brief     Helper functions for the @c GHC.Eventlog.Socket module.
+/// @details   This module declares wrappers for some of the functions
+///            exported by @c eventlog_socket.h for use in the Haskell
+///            module @c GHC.Eventlog.Socket.
+/// @author    Wen Kokke
+/// @version   0.1.2.1
+/// @date      2025-2026
+/// @copyright BSD-3-Clause License.
+///
+
+#include "./macros.h"
+#include <eventlog_socket.h>
+
+HIDDEN void es_hsapi_start(EventlogSocketStatus *eventlog_socket_status,
+                           EventlogSocketAddr *eventlog_socket_addr,
+                           EventlogSocketOpts *eventlog_socket_opts);
+
+HIDDEN void es_hsapi_from_env(EventlogSocketStatus *eventlog_socket_status,
+                              EventlogSocketAddr *eventlog_socket_addr,
+                              EventlogSocketOpts *eventlog_socket_opts);
+
+HIDDEN char *es_hsapi_strerror(EventlogSocketStatus *eventlog_socket_status);
+
+HIDDEN void
+es_hsapi_register_hook(EventlogSocketStatus *eventlog_socket_status,
+                       EventlogSocketHook eventlog_socket_hook,
+                       EventlogSocketHookHandler eventlog_socket_hook_handler,
+                       const void *eventlog_socket_hook_data);
+
+HIDDEN void
+es_hsapi_worker_status(EventlogSocketStatus *eventlog_socket_status_out);
+
+HIDDEN void
+es_hsapi_control_status(EventlogSocketStatus *eventlog_socket_status_out);
+
+HIDDEN void es_hsapi_control_register_namespace(
+    EventlogSocketStatus *eventlog_socket_status,
+    uint8_t eventlog_socket_namespace_len,
+    char eventlog_socket_namespace[eventlog_socket_namespace_len],
+    EventlogSocketControlNamespace **eventlog_socket_namespace_out);
+
+HIDDEN void es_hsapi_control_register_command(
+    EventlogSocketStatus *eventlog_socket_status,
+    EventlogSocketControlNamespace *eventlog_socket_namespace,
+    EventlogSocketControlCommandId eventlog_socket_command_id,
+    EventlogSocketControlCommandHandler eventlog_socket_command_handler,
+    const void *eventlog_socket_command_data);

--- a/eventlog-socket/eventlog-socket.cabal
+++ b/eventlog-socket/eventlog-socket.cabal
@@ -31,6 +31,8 @@ extra-source-files:
   cbits/eventlog_socket/error.h
   cbits/eventlog_socket/hooks.c
   cbits/eventlog_socket/hooks.h
+  cbits/eventlog_socket/hsapi.c
+  cbits/eventlog_socket/hsapi.h
   cbits/eventlog_socket/init_state.h
   cbits/eventlog_socket/macros.h
   cbits/eventlog_socket/poll.h
@@ -101,6 +103,7 @@ library
   c-sources:
     cbits/eventlog_socket/error.c
     cbits/eventlog_socket/hooks.c
+    cbits/eventlog_socket/hsapi.c
     cbits/eventlog_socket/string.c
     cbits/eventlog_socket/worker.c
     cbits/eventlog_socket/write_buffer.c

--- a/eventlog-socket/include/eventlog_socket.h
+++ b/eventlog-socket/include/eventlog_socket.h
@@ -182,6 +182,7 @@ void eventlog_socket_opts_free(EventlogSocketOpts *opts);
 /// to determine the host name for a TCP/IPv4 socket.
 ///
 /// @since 0.1.2.0
+// NOTE: Keep in sync with eventlogSocketEnvInetHost in Socket.hsc.
 #define EVENTLOG_SOCKET_ENV_INET_HOST "GHC_EVENTLOG_INET_HOST"
 
 /// @brief
@@ -189,6 +190,7 @@ void eventlog_socket_opts_free(EventlogSocketOpts *opts);
 /// to determine the port number for a TCP/IPv4 socket.
 ///
 /// @since 0.1.2.0
+// NOTE: Keep in sync with eventlogSocketEnvInetPort in Socket.hsc.
 #define EVENTLOG_SOCKET_ENV_INET_PORT "GHC_EVENTLOG_INET_PORT"
 
 /// @brief

--- a/eventlog-socket/src/GHC/Eventlog/Socket.hsc
+++ b/eventlog-socket/src/GHC/Eventlog/Socket.hsc
@@ -257,11 +257,26 @@ fromEnv =
 --------------------------------------------------------------------------------
 -- Environment variables
 
-eventlogSocketEnvInetHost :: String
-eventlogSocketEnvInetHost = #{const_str EVENTLOG_SOCKET_ENV_INET_HOST}
+{- |
+The name of the environment variable used by `eventlog_socket_from_env`
+to determine the host name for a TCP/IPv4 socket.
 
+@since 0.1.2.0
+-}
+eventlogSocketEnvInetHost :: String
+-- NOTE: Keep in sync with EVENTLOG_SOCKET_ENV_INET_HOST in eventlog_socketh.h.
+eventlogSocketEnvInetHost = "GHC_EVENTLOG_INET_HOST"
+
+
+{- |
+The name of the environment variable used by `eventlog_socket_from_env`
+to determine the port number for a TCP/IPv4 socket.
+
+@since 0.1.2.0
+-}
 eventlogSocketEnvInetPort :: String
-eventlogSocketEnvInetPort = #{const_str EVENTLOG_SOCKET_ENV_INET_PORT}
+-- NOTE: Keep in sync with EVENTLOG_SOCKET_ENV_INET_PORT in eventlog_socketh.h.
+eventlogSocketEnvInetPort = "GHC_EVENTLOG_INET_PORT"
 
 --------------------------------------------------------------------------------
 -- Errors

--- a/eventlog-socket/src/GHC/Eventlog/Socket.hsc
+++ b/eventlog-socket/src/GHC/Eventlog/Socket.hsc
@@ -257,17 +257,11 @@ fromEnv =
 --------------------------------------------------------------------------------
 -- Environment variables
 
-eventlogSocketEnvUnixPath :: String
-eventlogSocketEnvUnixPath = #{const_str EVENTLOG_SOCKET_ENV_UNIX_PATH}
-
 eventlogSocketEnvInetHost :: String
 eventlogSocketEnvInetHost = #{const_str EVENTLOG_SOCKET_ENV_INET_HOST}
 
 eventlogSocketEnvInetPort :: String
 eventlogSocketEnvInetPort = #{const_str EVENTLOG_SOCKET_ENV_INET_PORT}
-
-eventlogSocketEnvWait :: String
-eventlogSocketEnvWait = #{const_str EVENTLOG_SOCKET_ENV_WAIT}
 
 --------------------------------------------------------------------------------
 -- Errors

--- a/eventlog-socket/src/GHC/Eventlog/Socket.hsc
+++ b/eventlog-socket/src/GHC/Eventlog/Socket.hsc
@@ -89,9 +89,8 @@ import Foreign.Marshal.Utils (fromBool, toBool, with)
 import GHC.Enum (toEnumError)
 import System.IO.Unsafe (unsafePerformIO)
 
-#include <eventlog_socket/macros.h>
 #include <eventlog_socket.h>
-#include <string.h>
+#include <eventlog_socket/hsapi.h>
 
 --------------------------------------------------------------------------------
 -- High-level API
@@ -998,52 +997,22 @@ foreign import capi safe "eventlog_socket.h eventlog_socket_opts_free"
 --------------------------------------------------------------------------------
 -- eventlog_socket_start
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_start"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_start"
     eventlog_socket_start ::
         Ptr EventlogSocketStatus ->
         Ptr EventlogSocketAddr ->
         Ptr EventlogSocketOpts ->
         IO ()
 
-#{def
-  HIDDEN void eventlog_socket_wrap_start(
-    EventlogSocketStatus *eventlog_socket_status,
-    EventlogSocketAddr *eventlog_socket_addr,
-    EventlogSocketOpts *eventlog_socket_opts
-  )
-  {
-    const EventlogSocketStatus status = eventlog_socket_start(
-      eventlog_socket_addr,
-      eventlog_socket_opts
-    );
-    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
-  }
-}
-
 --------------------------------------------------------------------------------
 -- eventlog_socket_from_env
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_from_env"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_from_env"
     eventlog_socket_from_env ::
         Ptr EventlogSocketStatus ->
         Ptr EventlogSocketAddr ->
         Ptr EventlogSocketOpts ->
         IO ()
-
-#{def
-  HIDDEN void eventlog_socket_wrap_from_env(
-    EventlogSocketStatus *eventlog_socket_status,
-    EventlogSocketAddr *eventlog_socket_addr,
-    EventlogSocketOpts *eventlog_socket_opts
-  )
-  {
-    const EventlogSocketStatus status = eventlog_socket_from_env(
-      eventlog_socket_addr,
-      eventlog_socket_opts
-    );
-    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
-  }
-}
 
 --------------------------------------------------------------------------------
 -- eventlog_socket_wait
@@ -1054,24 +1023,15 @@ foreign import capi safe "eventlog_socket.h eventlog_socket_wait"
 --------------------------------------------------------------------------------
 -- eventlog_socket_strerror
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_strerror"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_strerror"
     eventlog_socket_strerror ::
         Ptr EventlogSocketStatus ->
         IO CString
 
-#{def
-  HIDDEN char *eventlog_socket_wrap_strerror(
-    EventlogSocketStatus *eventlog_socket_status
-  )
-  {
-    return eventlog_socket_strerror(*eventlog_socket_status);
-  }
-}
-
 --------------------------------------------------------------------------------
 -- eventlog_socket_register_hook
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_register_hook"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_register_hook"
     eventlog_socket_register_hook ::
         Ptr EventlogSocketStatus ->
         Hook ->
@@ -1084,57 +1044,20 @@ foreign import ccall "wrapper"
         (Ptr a -> IO ()) ->
         IO (FunPtr (Ptr a -> IO ()))
 
-#{def
-  HIDDEN void eventlog_socket_wrap_register_hook(
-    EventlogSocketStatus *eventlog_socket_status,
-    EventlogSocketHook eventlog_socket_hook,
-    EventlogSocketHookHandler eventlog_socket_hook_handler,
-    const void *eventlog_socket_hook_data
-  ) {
-    const EventlogSocketStatus status = eventlog_socket_register_hook(
-      eventlog_socket_hook,
-      eventlog_socket_hook_handler,
-      eventlog_socket_hook_data
-    );
-    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
-  }
-}
-
 --------------------------------------------------------------------------------
 -- eventlog_socket_worker_status
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_worker_status"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_worker_status"
     eventlog_socket_worker_status ::
         Ptr EventlogSocketStatus ->
         IO ()
-
-#{def
-  HIDDEN void eventlog_socket_wrap_worker_status(
-    EventlogSocketStatus *eventlog_socket_status_out
-  )
-  {
-    const EventlogSocketStatus eventlog_socket_status = eventlog_socket_worker_status();
-    memcpy(eventlog_socket_status_out, &eventlog_socket_status, sizeof(EventlogSocketStatus));
-  }
-}
-
 --------------------------------------------------------------------------------
 -- eventlog_socket_control_status
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_control_status"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_control_status"
     eventlog_socket_control_status ::
         Ptr EventlogSocketStatus ->
         IO ()
-
-#{def
-  HIDDEN void eventlog_socket_wrap_control_status(
-    EventlogSocketStatus *eventlog_socket_status_out
-  )
-  {
-    const EventlogSocketStatus eventlog_socket_status = eventlog_socket_control_status();
-    memcpy(eventlog_socket_status_out, &eventlog_socket_status, sizeof(EventlogSocketStatus));
-  }
-}
 
 --------------------------------------------------------------------------------
 -- eventlog_socket_control_strnamespace
@@ -1150,7 +1073,7 @@ foreign import ccall safe "eventlog_socket.h eventlog_socket_control_strnamespac
 --------------------------------------------------------------------------------
 -- eventlog_socket_control_register_namespace
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_control_register_namespace"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_control_register_namespace"
     eventlog_socket_control_register_namespace ::
         Ptr EventlogSocketStatus ->
         ( #{type uint8_t} ) ->
@@ -1158,26 +1081,10 @@ foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_control
         Ptr (Ptr Namespace) ->
         IO ()
 
-#{def
-  HIDDEN void eventlog_socket_wrap_control_register_namespace(
-    EventlogSocketStatus *eventlog_socket_status,
-    uint8_t eventlog_socket_namespace_len,
-    char eventlog_socket_namespace[eventlog_socket_namespace_len],
-    EventlogSocketControlNamespace **eventlog_socket_namespace_out
-  ) {
-    const EventlogSocketStatus status = eventlog_socket_control_register_namespace(
-      eventlog_socket_namespace_len,
-      eventlog_socket_namespace,
-      eventlog_socket_namespace_out
-    );
-    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
-  }
-}
-
 --------------------------------------------------------------------------------
 -- eventlog_socket_control_register_command
 
-foreign import capi safe "GHC/Eventlog/Socket_hsc.h eventlog_socket_wrap_control_register_command"
+foreign import capi safe "eventlog_socket/hsapi.h es_hsapi_control_register_command"
     eventlog_socket_control_register_command ::
         Ptr EventlogSocketStatus ->
         Ptr Namespace ->
@@ -1190,21 +1097,3 @@ foreign import ccall "wrapper"
     makeCommandHandlerFunPtr ::
         (Ptr Namespace -> CommandId -> Ptr a -> IO ()) ->
         IO (FunPtr (Ptr Namespace -> CommandId -> Ptr a -> IO ()))
-
-#{def
-  HIDDEN void eventlog_socket_wrap_control_register_command(
-    EventlogSocketStatus *eventlog_socket_status,
-    EventlogSocketControlNamespace *eventlog_socket_namespace,
-    EventlogSocketControlCommandId eventlog_socket_command_id,
-    EventlogSocketControlCommandHandler eventlog_socket_command_handler,
-    const void *eventlog_socket_command_data
-  ) {
-    const EventlogSocketStatus status = eventlog_socket_control_register_command(
-      eventlog_socket_namespace,
-      eventlog_socket_command_id,
-      eventlog_socket_command_handler,
-      eventlog_socket_command_data
-    );
-    memcpy(eventlog_socket_status, &status, sizeof(EventlogSocketStatus));
-  }
-}

--- a/scripts/build-from-sdist.sh
+++ b/scripts/build-from-sdist.sh
@@ -48,6 +48,9 @@ find "${BUILDDIR}" -type d -mindepth 1 -maxdepth 1 -not -name 'sdist' | while IF
 	echo "packages: ${pkg}" >> "${CABAL_PROJECT}"
 done
 
+# Append cabal.project.config file:
+echo >> "${CABAL_PROJECT}"
+cat "${REPO_ROOT_DIR}/cabal.project.config" >> "${CABAL_PROJECT}"
 
 # Build all packages:
 ${CABAL} build all --builddir="${BUILDDIR}" --project-dir="${BUILDDIR}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,16 +7,41 @@
 #       the error stream. Otherwise, it shows only the output stream and logs
 #       only the error stream.
 
-# Get the project root directory:
-ROOT_DIR="$(CDPATH= cd -- "$(dirname "$(dirname "$(dirname -- "$0")")")" && pwd)"
+# Find the repository root directory
+REPO_ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$(dirname -- "$0")")" && pwd)"
+
+# Read the expected version:
+EXPECT_VERSION="$(awk -F'=' '/^cabal=/{print$2}' ./scripts/dev-dependencies.txt)"
+
+# Find cabal:
+#
+# 1. Use CABAL if it is set.
+# 2. Look for cabal-$EXPECTED_VERSION.
+# 3. Look for cabal.
+#
+if [ "${CABAL}" = "" ]; then
+  if ! CABAL="$(which "cabal-${EXPECT_VERSION}")"; then
+    if ! CABAL="$(which "cabal")"; then
+      echo "Requires cabal ${EXPECT_VERSION}; no version found"
+      exit 1
+    fi
+  fi
+fi
+
+# Check cabal version:
+ACTUAL_VERSION="$("${CABAL}" --numeric-version | head -n 1)"
+if [ "${ACTUAL_VERSION}" != "${EXPECT_VERSION}" ]; then
+  # Version mismatch is never an error:
+  echo "Requires cabal ${EXPECT_VERSION}; version ${ACTUAL_VERSION} found"
+fi
 
 # Log file for stderr.
-ERR_FILE="${ROOT_DIR}/eventlog-socket-tests.err.log"
+ERR_FILE="${REPO_ROOT_DIR}/eventlog-socket-tests.err.log"
 
 # Run test command.
 if [ -n "${DEBUG+x}" ]; then
 	# Log file for stdout.
-	OUT_FILE="${ROOT_DIR}/eventlog-socket-tests.out.log"
+	OUT_FILE="${REPO_ROOT_DIR}/eventlog-socket-tests.out.log"
 
 	# Pipe for stderr.
 	ERR_FIFO="${TMPDIR:-/tmp}/eventlog-socket-tests.err.$$"
@@ -25,7 +50,7 @@ if [ -n "${DEBUG+x}" ]; then
 	tee "${ERR_FILE}" <"${ERR_FIFO}" >&2 &
 
 	# Run test suite and log debug information.
-	cabal run eventlog-socket-tests --enable-tests -f+debug "$@" >"${OUT_FILE}" 2>"${ERR_FIFO}"
+	${CABAL} run eventlog-socket-tests --enable-tests -f+debug "$@" >"${OUT_FILE}" 2>"${ERR_FIFO}"
 else
-	cabal run eventlog-socket-tests --enable-tests -f+debug "$@" 2>"${ERR_FILE}"
+	${CABAL} run eventlog-socket-tests --enable-tests -f+debug "$@" 2>"${ERR_FILE}"
 fi


### PR DESCRIPTION
This PR removes uses of `#{const_str}` and `#{def}` to support building with hsc2hs in cross-compilation mode.