### PR TITLE
Support `startProfTimer` and `stopProfTimer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ For an example of an application that registers lifecycle hooks using the C API,
 
 When compiled with the `+control` feature flag, the eventlog socket supports *control commands*. These are messages that can be *written to* the eventlog socket by the client to control the RTS or execute custom control commands.
 
-The `eventlog-socket` package provides three built-in commands:
+The `eventlog-socket` package provides five built-in commands:
 
-1. The `startHeapProfiling` control command starts heap profiling.
-2. The `stopHeapProfiling` control command stops heap profiling.
-3. The `requestHeapCensus` control command requests a single heap profile.
+1. The `startProfiling` control command starts cost-centre profiling.
+2. The `stopProfiling` control command stops cost-centre profiling.
+3. The `startHeapProfiling` control command starts heap profiling.
+4. The `stopHeapProfiling` control command stops heap profiling.
+5. The `requestHeapCensus` control command requests a single heap profile.
 
 The heap profiling commands require that the RTS is initialised with one of the `-h` options. See [RTS options for heap profiling](https://downloads.haskell.org/ghc/latest/docs/users_guide/profiling.html#rts-options-heap-prof). If any heap profiling option is passed, heap profiling is started by default. To avoid this, pass the `--no-automatic-heap-samples` to the RTS *in addition to* the selected `-h` option, e.g., `./my-app +RTS -hT --no-automatic-heap-samples -RTS`.
 
@@ -160,11 +162,13 @@ namespace        = {byte}; (* must be exactly namespace-len bytes *)
 command-id       = byte;   (* commands are assigned numeric IDs *)
 ```
 
-The built-in commands live in the `"eventlog-socket"` namespace and are numbered in order starting at 3.
+The built-in commands live in the `"eventlog-socket"` namespace and are numbered in order starting at 1.
 
-1. The message for `startHeapProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x03`.
-2. The message for `stopHeapProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x04`.
-3. The message for `requestHeapCensus` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x05`.
+1. The message for `startProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x01`.
+2. The message for `stopProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x02`.
+3. The message for `startHeapProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x03`.
+4. The message for `stopHeapProfiling` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x04`.
+5. The message for `requestHeapCensus` is `\xF0\x9E\x97\x8C\x00\x15eventlog-socket\x05`.
 
 For example, a simple Python client using the [`socket`](https://docs.python.org/3/library/socket.html) library could request a heap census as follows:
 

--- a/eventlog-socket-control/CHANGELOG.md
+++ b/eventlog-socket-control/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for eventlog-socket-command
 
+## 0.1.1.0 -- 2026-04-06
+
+- Add support for builtin `startProfiling` and `stopProfiling` control commands.
+
 ## 0.1.0.0 -- 2026-03-04
 
-* First version. Released on an unsuspecting world.
+- Add support the binary control command protocol version 0.
+- Add support for builtin `startHeapProfiling`, `stopHeapProfiling`, and `requestHeapCensus` control commands.

--- a/eventlog-socket-control/src/GHC/Eventlog/Socket/Control.hs
+++ b/eventlog-socket-control/src/GHC/Eventlog/Socket/Control.hs
@@ -31,6 +31,8 @@ module GHC.Eventlog.Socket.Control (
     Command,
     CommandId (..),
     Namespace,
+    startProfiling,
+    stopProfiling,
     startHeapProfiling,
     stopHeapProfiling,
     requestHeapCensus,
@@ -374,6 +376,26 @@ instance Binary Command where
 --------------------------------------------------------------------------------
 -- Builtin Commands
 --------------------------------------------------------------------------------
+
+{- |
+The builtin control command message that starts profiling.
+
+See `GHC.Profiling.startProfTimer`.
+
+@since 0.1.1.0
+-}
+startProfiling :: Command
+startProfiling = Command eventlogSocketNamespace (CommandId 1)
+
+{- |
+The builtin control command message that stops profiling.
+
+See `GHC.Profiling.stopProfTimer`.
+
+@since 0.1.1.0
+-}
+stopProfiling :: Command
+stopProfiling = Command eventlogSocketNamespace (CommandId 2)
 
 {- |
 The builtin control command message that starts heap profiling.

--- a/eventlog-socket/CHANGELOG.md
+++ b/eventlog-socket/CHANGELOG.md
@@ -17,6 +17,8 @@
 
   To avoid races, it is important that these hooks are registered *before* `eventlog-socket` is started.
 
+- Add support for builtin `startProfiling` and `stopProfiling` control commands.
+
 ## 0.1.2.0 -- 2026-03-25
 
 **Warning**: The C API exposed from this version contains breaking changes over the C API exposed from version 0.1.1.0. This is justified by the fact that the C API exposed from version 0.1.1.0 is broken and that version is deprecated and not known to be in use.

--- a/eventlog-socket/cbits/eventlog_socket/control.c
+++ b/eventlog-socket/cbits/eventlog_socket/control.c
@@ -37,6 +37,7 @@
 #include "./poll.h"
 #include "eventlog_socket.h"
 #include "init_state.h"
+#include "rts/prof/CCS.h"
 
 // CONTROL_MAGIC should be the UTF-8 encoding of some code point between
 // U+010000 and U+10FFFF. Let's pick code point U+01E5CC, for Eventlog
@@ -77,11 +78,11 @@ static const uint8_t g_control_magic[CONTROL_MAGIC_LEN] = {
 /// @brief The name of the builtin namespace.
 #define BUILTIN_NAMESPACE "eventlog-socket"
 
-/// @brief The ID reserved for the builtin `StartEventLogging` command.
-#define BUILTIN_COMMAND_ID_START_EVENT_LOGGING 1
+/// @brief The ID of the builtin `StartProfiling` command.
+#define BUILTIN_COMMAND_ID_START_PROFILING 1
 
-/// @brief The ID reserved for the builtin `EndEventLogging` command.
-#define BUILTIN_COMMAND_ID_END_EVENT_LOGGING 2
+/// @brief The ID of the builtin `StopProfiling` command.
+#define BUILTIN_COMMAND_ID_STOP_PROFILING 2
 
 /// @brief The ID of the builtin `StartHeapProfiling` command.
 #define BUILTIN_COMMAND_ID_START_HEAP_PROFILING 3
@@ -96,7 +97,30 @@ static const uint8_t g_control_magic[CONTROL_MAGIC_LEN] = {
  * Handlers for Builtin Commands
  ******************************************************************************/
 
-/// @brief Handler for "StartHeapProfiling" command (eventlog-socket::0).
+/// @brief Handler for "StartProfiling" command (eventlog-socket::1).
+static void es_control_start_profiling(
+    const EventlogSocketControlNamespace *const namespace,
+    const EventlogSocketControlCommandId command_id, const void *user_data) {
+  (void)namespace;
+  (void)command_id;
+  (void)user_data;
+  startProfTimer();
+  DEBUG_DEBUG("%s", "Started profiling.");
+}
+
+/// @brief Handler for "StopProfiling" command (eventlog-socket::2).
+static void
+es_control_stop_profiling(const EventlogSocketControlNamespace *const namespace,
+                          const EventlogSocketControlCommandId command_id,
+                          const void *user_data) {
+  (void)namespace;
+  (void)command_id;
+  (void)user_data;
+  stopProfTimer();
+  DEBUG_DEBUG("%s", "Stopped profiling.");
+}
+
+/// @brief Handler for "StartHeapProfiling" command (eventlog-socket::3).
 static void es_control_start_heap_profiling(
     const EventlogSocketControlNamespace *const namespace,
     const EventlogSocketControlCommandId command_id, const void *user_data) {
@@ -107,7 +131,7 @@ static void es_control_start_heap_profiling(
   DEBUG_DEBUG("%s", "Started heap profiling.");
 }
 
-/// @brief Handler for "StopHeapProfiling" command (eventlog-socket::1).
+/// @brief Handler for "StopHeapProfiling" command (eventlog-socket::4).
 static void es_control_stop_heap_profiling(
     const EventlogSocketControlNamespace *const namespace,
     const EventlogSocketControlCommandId command_id, const void *user_data) {
@@ -118,7 +142,7 @@ static void es_control_stop_heap_profiling(
   DEBUG_DEBUG("%s", "Stopped heap profiling.");
 }
 
-/// @brief Handler for "RequestHeapCensus" command (eventlog-socket::2).
+/// @brief Handler for "RequestHeapCensus" command (eventlog-socket::5).
 static void es_control_request_heap_census(
     const EventlogSocketControlNamespace *const namespace,
     const EventlogSocketControlCommandId command_id, const void *user_data) {
@@ -193,21 +217,37 @@ static EventlogSocketControlNamespace g_control_namespace_registry = {
     .next = NULL,
     .command_registry =
         &(EventlogSocketControlCommand){
-            .command_id = BUILTIN_COMMAND_ID_START_HEAP_PROFILING,
-            .command_handler = es_control_start_heap_profiling,
+            .command_id = BUILTIN_COMMAND_ID_START_PROFILING,
+            .command_handler = es_control_start_profiling,
             .command_data = NULL,
             .next =
                 &(EventlogSocketControlCommand){
-                    .command_id = BUILTIN_COMMAND_ID_STOP_HEAP_PROFILING,
-                    .command_handler = es_control_stop_heap_profiling,
+                    .command_id = BUILTIN_COMMAND_ID_STOP_PROFILING,
+                    .command_handler = es_control_stop_profiling,
                     .command_data = NULL,
                     .next =
                         &(EventlogSocketControlCommand){
                             .command_id =
-                                BUILTIN_COMMAND_ID_REQUEST_HEAP_CENSUS,
-                            .command_handler = es_control_request_heap_census,
+                                BUILTIN_COMMAND_ID_START_HEAP_PROFILING,
+                            .command_handler = es_control_start_heap_profiling,
                             .command_data = NULL,
-                            .next = NULL,
+                            .next =
+                                &(EventlogSocketControlCommand){
+                                    .command_id =
+                                        BUILTIN_COMMAND_ID_STOP_HEAP_PROFILING,
+                                    .command_handler =
+                                        es_control_stop_heap_profiling,
+                                    .command_data = NULL,
+                                    .next =
+                                        &(EventlogSocketControlCommand){
+                                            .command_id =
+                                                BUILTIN_COMMAND_ID_REQUEST_HEAP_CENSUS,
+                                            .command_handler =
+                                                es_control_request_heap_census,
+                                            .command_data = NULL,
+                                            .next = NULL,
+                                        },
+                                },
                         },
                 },
         },


### PR DESCRIPTION
This PR adds two new builtin custom commands for `startProfTimer` and `stopProfTimer`.