### PR TITLE
Fix program build logic in `eventlog-socket-tests`

### DIFF
--- a/eventlog-socket-tests/eventlog-socket-tests.cabal
+++ b/eventlog-socket-tests/eventlog-socket-tests.cabal
@@ -72,6 +72,7 @@ library
     , binary                   >=0.8   && <0.9
     , bytestring               >=0.11  && <0.13
     , containers               >=0.7   && <0.8
+    , directory                >=1.0   && <1.4
     , eventlog-socket          >=0.1.3 && <0.2
     , eventlog-socket-control  >=0.1.1 && <0.2
     , filepath                 >=1.5   && <1.6

--- a/eventlog-socket-tests/eventlog-socket-tests.cabal
+++ b/eventlog-socket-tests/eventlog-socket-tests.cabal
@@ -77,6 +77,7 @@ library
     , eventlog-socket-control  >=0.1.1 && <0.2
     , filepath                 >=1.5   && <1.6
     , ghc-events               >=0.20  && <0.21
+    , hashable                 >=1.0   && <1.6
     , machines                 >=0.7.4 && <0.8
     , network                  >=3.2.7 && <3.3
     , process                  >=1.6   && <1.7

--- a/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
+++ b/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Eventlog.Socket.Test (
     -- * Example Programs
@@ -75,6 +76,9 @@ module GHC.Eventlog.Socket.Test (
     Message (..),
     debug,
     debugEvents,
+
+    -- * Custom options
+    keepProgramBuildOption,
 ) where
 
 import Control.Concurrent (forkIO, killThread, threadDelay)
@@ -94,6 +98,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Machine
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
+import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Word (Word16, Word64)
 import GHC.Clock (getMonotonicTimeNSec)
@@ -114,8 +119,9 @@ import System.IO.Error (ioeGetErrorString, ioeGetLocation, isEOFError)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Process (CreateProcess (..), Pid, ProcessHandle, StdStream (..), createProcess_, getPid, getProcessExitCode, proc, readProcessWithExitCode, showCommandForUser, terminateProcess, waitForProcess)
 import System.Process.Internals (ignoreSigPipe)
-import Test.Tasty (TestName, TestTree, testGroup, withResource)
+import Test.Tasty (TestName, TestTree, askOption, testGroup, withResource)
 import Test.Tasty.HUnit (Assertion, HasCallStack, assertFailure, testCase)
+import Test.Tasty.Options (IsOption (..), OptionDescription (..), safeReadBool)
 import Text.Printf (printf)
 
 #if defined(DEBUG)
@@ -123,6 +129,27 @@ import qualified Control.Concurrent.STM as T
 import GHC.RTS.Events (TimeFormat (..), ppEvent)
 import System.Posix.Types (CPid (..))
 #endif
+
+--------------------------------------------------------------------------------
+-- Tasty Options
+--------------------------------------------------------------------------------
+
+newtype KeepProgramBuild = KeepProgramBuild Bool
+
+instance IsOption KeepProgramBuild where
+    defaultValue :: KeepProgramBuild
+    defaultValue = KeepProgramBuild False
+    parseValue :: String -> Maybe KeepProgramBuild
+    parseValue = fmap KeepProgramBuild . safeReadBool
+
+    -- optionName :: Tagged KeepProgramBuild String
+    optionName = "keep-program-build"
+
+    -- optionHelp :: Tagged KeepProgramBuild String
+    optionHelp = "If true, keep the cabal build directories for the test programs."
+
+keepProgramBuildOption :: OptionDescription
+keepProgramBuildOption = Option (Proxy :: Proxy KeepProgramBuild)
 
 --------------------------------------------------------------------------------
 -- Example Programs
@@ -1050,9 +1077,11 @@ runProgramTests = fmap toTestGroup . groupByDesc
     toTestGroup (pt :| pts) =
         -- Assert that all tests have the same program description.
         assert (all (((==) `on` (.programDesc)) pt) pts) $
-            withResource pt.makeProgram pt.freeProgram $ \findProgram ->
-                testGroup ("With program " <> pt.programDesc <> ":") $
-                    [pt'.testProgram findProgram | pt' <- (pt : pts)]
+            askOption @KeepProgramBuild $ \(KeepProgramBuild keepProgramBuild) -> do
+                let maybeFreeProgram programBin = if keepProgramBuild then pure () else pt.freeProgram programBin
+                withResource pt.makeProgram maybeFreeProgram $ \findProgram ->
+                    testGroup ("With program " <> pt.programDesc <> ":") $
+                        [pt'.testProgram findProgram | pt' <- (pt : pts)]
 
 inetPortCounter :: MVar Word16
 inetPortCounter = unsafePerformIO (newMVar 0)

--- a/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
+++ b/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
@@ -202,29 +202,99 @@ programResource program = ProgramResource{..}
         ghc <- fromMaybe "ghc" <$> lookupEnv "GHC"
         cabal <- fromMaybe "cabal" <$> lookupEnv "CABAL"
 
-        -- Build program
-        debugInfo $ "Build program " <> program.name <> " with " <> ghc <> " and " <> cabal
-        let buildArgs = ["build", program.name, "-w" <> ghc, "--builddir", buildDir] <> buildFlags
-        debugInfo (showCommandForUser cabal buildArgs)
-        (buildExit, buildOut, buildErr) <- readProcessWithExitCode cabal buildArgs ""
-        when (buildExit /= ExitSuccess) $ do
-            debugFail . unlines $ ["Failed to build program", buildOut, buildErr]
-            throwIO buildExit
+        -- Build the program binary
+        let buildProgram :: IO ()
+            buildProgram = do
+                -- Start building program binary
+                debugInfo $ "Build program " <> program.name <> " with " <> ghc <> " and " <> cabal
+                let buildArgs = ["build", program.name, "-w" <> ghc, "--builddir", buildDir] <> buildFlags
+                debugInfo (showCommandForUser cabal buildArgs)
+                let createProcess =
+                        (proc cabal buildArgs)
+                            { std_in = CreatePipe
+                            , std_out = CreatePipe
+                            , std_err = CreatePipe
+                            }
+                (maybeHandleIn, maybeHandleOut, maybeHandleErr, processHandle) <- createProcess_ "cabal" createProcess
 
-        -- Find binary for program
-        debugInfo $ "Find binary for program " <> program.name
-        let findArgs = ["list-bin", program.name, "-w" <> ghc, "--builddir", buildDir] <> buildFlags
-        debugInfo (showCommandForUser cabal findArgs)
-        (findExit, findOut, findErr) <- readProcessWithExitCode cabal findArgs ""
-        when (findExit /= ExitSuccess) $ do
-            debugFail . unlines $ ["Failed to find binary for program ", findOut, findErr]
-            throwIO findExit
-        let maybeProgramBin = fmap fst . L.uncons . lines $ findOut
-        programBin <- flip (`maybe` pure) maybeProgramBin $ do
-            debugFail . unlines $ ["Failed to find binary for program ", findOut, findErr]
-            throwIO findExit
+                -- Create the ProgramInfo:
+                let cabalProgram = Program{name = "cabal", args = buildArgs, rtsopts = [], eventlogSocketBuildFlags = []}
+                let cabalProgramPidIO = getPid processHandle
+                cabalProgramPid <- cabalProgramPidIO
+                let cabalInfo = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
+                let ?programInfo = cabalInfo
+
+                -- Start loggers for stderr and stdout:
+                maybeKillDebugOut <- traverse (debugHandle $ ProgramOut cabalInfo) maybeHandleOut
+                maybeKillDebugErr <- traverse (debugHandle $ ProgramErr cabalInfo) maybeHandleErr
+                let kill = mask_ $ do
+                        debugInfo $ "Cleaning up stdout reader for " <> program.name <> "."
+                        sequence_ maybeKillDebugOut
+                        debugInfo $ "Cleaning up stderr reader for " <> program.name <> "."
+                        sequence_ maybeKillDebugErr
+                        debugInfo $ "Cleaning up process for " <> program.name <> "."
+                        exitCode <- murderProcess program.name (maybeHandleIn, maybeHandleOut, maybeHandleErr, processHandle)
+                        debugInfo $ "Process was killed with exit code " <> show exitCode
+                        pure ()
+                let wait = do
+                        debugInfo $ "Waiting for " <> program.name <> " to finish."
+                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode ->
+                            when (exitCode /= ExitSuccess) . assertFailure $
+                                "Program " <> program.name <> " failed with exit code " <> show exitCode
+
+                -- Wait for building program to finish
+                wait
+
+        buildProgram
+
+        -- Find the program binary
+        let findProgram :: IO FilePath
+            findProgram = do
+                debugInfo $ "Find binary for program " <> program.name
+                let findArgs = ["list-bin", program.name, "-w" <> ghc, "--builddir", buildDir] <> buildFlags
+                debugInfo (showCommandForUser cabal findArgs)
+                let createProcess =
+                        (proc cabal findArgs)
+                            { std_in = CreatePipe
+                            , std_out = CreatePipe
+                            , std_err = CreatePipe
+                            }
+                (maybeHandleIn, Just handleOut, maybeHandleErr, processHandle) <- createProcess_ "cabal" createProcess
+
+                -- Create the ProgramInfo:
+                let cabalProgram = Program{name = "cabal", args = findArgs, rtsopts = [], eventlogSocketBuildFlags = []}
+                let cabalProgramPidIO = getPid processHandle
+                cabalProgramPid <- cabalProgramPidIO
+                let cabalInfo = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
+                let ?programInfo = cabalInfo
+
+                -- Start loggers for stderr and stdout:
+                maybeKillDebugErr <- traverse (debugHandle $ ProgramErr cabalInfo) maybeHandleErr
+                let kill = mask_ $ do
+                        debugInfo $ "Cleaning up stderr reader for " <> program.name <> "."
+                        sequence_ maybeKillDebugErr
+                        debugInfo $ "Cleaning up process for " <> program.name <> "."
+                        exitCode <- murderProcess program.name (maybeHandleIn, Just handleOut, maybeHandleErr, processHandle)
+                        debugInfo $ "Process was killed with exit code " <> show exitCode
+                        pure ()
+                let wait = do
+                        debugInfo $ "Waiting for " <> program.name <> " to finish."
+                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode ->
+                            when (exitCode /= ExitSuccess) . assertFailure $
+                                "Program " <> program.name <> " failed with exit code " <> show exitCode
+
+                wait
+
+                programBin <- IO.hGetContents handleOut
+
+                debugInfo $ "Found program binary at " <> programBin
+
+                pure programBin
+
+        programBin <- findProgram
 
         debug Footer
+
         pure programBin
 
     -- Free the program binary

--- a/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
+++ b/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
@@ -84,15 +84,15 @@ module GHC.Eventlog.Socket.Test (
 import Control.Concurrent (forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
 import Control.Exception (ErrorCall (..), Exception (..), assert, bracket, bracketOnError, catch, mask_, throwIO)
-import Control.Monad (filterM, unless, when)
+import Control.Monad (filterM, when)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.Binary as B
 import Data.Bool (bool)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
-import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Function (on, (&))
+import Data.Hashable (Hashable (..))
 import qualified Data.List as L
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -101,7 +101,6 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
-import Data.Traversable (for)
 import Data.Word (Word16, Word64)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Eventlog.Socket (EventlogSocketAddr (..))
@@ -112,6 +111,7 @@ import GHC.RTS.Events.Incremental (Decoder (..), decodeEventLog)
 import Network.Socket (Socket)
 import qualified Network.Socket as S
 import qualified Network.Socket.ByteString as SB
+import Numeric (showHex)
 import System.Directory (doesFileExist)
 import System.Environment (getEnvironment, lookupEnv)
 import System.Exit (ExitCode (..))
@@ -162,7 +162,7 @@ data Program = Program
     { name :: String
     , args :: [String]
     , rtsopts :: [String]
-    , eventlogSocketBuildFlags :: [String]
+    , buildFlags :: [String]
     }
 
 type HasProgramInfo = (?programInfo :: ProgramInfo)
@@ -190,38 +190,35 @@ data ProgramResource = ProgramResource
 
 buildFlagDebug :: [String]
 #if defined(DEBUG)
-buildFlagDebug = ["+debug"]
+buildFlagDebug = ["--constraint=eventlog-socket+debug"]
 #else
 buildFlagDebug = []
 #endif
 
 buildFlagDebugVerbosity :: [String]
 #if defined(DEBUG_VERBOSITY_TRACE)
-buildFlagDebugVerbosity = ["+debug-verbosity-trace"]
+buildFlagDebugVerbosity = ["--constraint=eventlog-socket+debug-verbosity-trace"]
 #else
 buildFlagDebugVerbosity = []
 #endif
 
 defaultBuildFlags :: [String]
-defaultBuildFlags = ["+optimise-heavily"] <> buildFlagDebug <> buildFlagDebugVerbosity
+defaultBuildFlags = ["--constraint=eventlog-socket+optimise-heavily"] <> buildFlagDebug <> buildFlagDebugVerbosity
 
 programResource :: (HasLogger, HasTestInfo) => Program -> ProgramResource
 programResource program = ProgramResource{..}
   where
     -- Shared information
-    eventlogSocketBuildFlags = program.eventlogSocketBuildFlags <> defaultBuildFlags
-    buildFlags
-        | null eventlogSocketBuildFlags = []
-        | otherwise = ["--constraint", "eventlog-socket " <> unwords eventlogSocketBuildFlags]
-    buildDir = "dist-newstyle/" <> L.intercalate "-" ("test" : program.name : eventlogSocketBuildFlags)
+    buildFlags = program.buildFlags <> defaultBuildFlags
+    buildDir = "dist-newstyle/" <> L.intercalate "-" ("test" : program.name : buildFlags)
 
     -- The program description
     programDesc :: TestName
     programDesc = program.name <> flagDesc
       where
         flagDesc
-            | null program.eventlogSocketBuildFlags = ""
-            | otherwise = "[" <> unwords program.eventlogSocketBuildFlags <> "]"
+            | null program.buildFlags = ""
+            | otherwise = "[" <> unwords program.buildFlags <> "]"
 
     -- Make the program binary
     makeProgram :: IO FilePath
@@ -248,7 +245,7 @@ programResource program = ProgramResource{..}
                 (maybeHandleIn, maybeHandleOut, maybeHandleErr, processHandle) <- createProcess_ "cabal" createProcess
 
                 -- Create the ProgramInfo:
-                let cabalProgram = Program{name = "cabal", args = buildArgs, rtsopts = [], eventlogSocketBuildFlags = []}
+                let cabalProgram = Program{name = "cabal", args = buildArgs, rtsopts = [], buildFlags = []}
                 let cabalProgramPidIO = getPid processHandle
                 cabalProgramPid <- cabalProgramPidIO
                 let info = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
@@ -291,7 +288,7 @@ programResource program = ProgramResource{..}
                 (maybeHandleIn, Just handleOut, maybeHandleErr, processHandle) <- createProcess_ "cabal" createProcess
 
                 -- Create the ProgramInfo:
-                let cabalProgram = Program{name = "cabal", args = findArgs, rtsopts = [], eventlogSocketBuildFlags = []}
+                let cabalProgram = Program{name = "cabal", args = findArgs, rtsopts = [], buildFlags = []}
                 let cabalProgramPidIO = getPid processHandle
                 cabalProgramPid <- cabalProgramPidIO
                 let cabalInfo = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
@@ -1125,7 +1122,15 @@ programTestFor testBaseName program eventlogAssertion = \case
                     debug Header
                     -- Update the eventlog socket to avoid conflicts
                     let (directory, fileName) = splitFileName esaUnixPath
-                    let unixPath' = directory </> testName <> "_" <> fileName
+                    let testHash = showHex hshW ""
+                          where
+                            hshI :: Int
+                            hshI = hash testName
+                            hshW :: Word
+                            hshW
+                                | hshI >= 0 = fromIntegral hshI + fromIntegral (maxBound :: Int)
+                                | otherwise = fromIntegral (abs hshI)
+                    let unixPath' = directory </> testHash <> "_" <> fileName
                     let eventlogSocketAddr = EventlogSocketUnixAddr unixPath'
                     -- Find and start the program
                     programBin <- findProgram

--- a/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
+++ b/eventlog-socket-tests/src/GHC/Eventlog/Socket/Test.hs
@@ -83,13 +83,14 @@ module GHC.Eventlog.Socket.Test (
 
 import Control.Concurrent (forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
-import Control.Exception (Exception (..), assert, bracket, bracketOnError, catch, mask_, throwIO)
-import Control.Monad (when)
+import Control.Exception (ErrorCall (..), Exception (..), assert, bracket, bracketOnError, catch, mask_, throwIO)
+import Control.Monad (filterM, unless, when)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.Binary as B
 import Data.Bool (bool)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Function (on, (&))
 import qualified Data.List as L
@@ -100,6 +101,7 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
+import Data.Traversable (for)
 import Data.Word (Word16, Word64)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Eventlog.Socket (EventlogSocketAddr (..))
@@ -110,6 +112,7 @@ import GHC.RTS.Events.Incremental (Decoder (..), decodeEventLog)
 import Network.Socket (Socket)
 import qualified Network.Socket as S
 import qualified Network.Socket.ByteString as SB
+import System.Directory (doesFileExist)
 import System.Environment (getEnvironment, lookupEnv)
 import System.Exit (ExitCode (..))
 import System.FilePath (splitFileName, (</>))
@@ -248,12 +251,12 @@ programResource program = ProgramResource{..}
                 let cabalProgram = Program{name = "cabal", args = buildArgs, rtsopts = [], eventlogSocketBuildFlags = []}
                 let cabalProgramPidIO = getPid processHandle
                 cabalProgramPid <- cabalProgramPidIO
-                let cabalInfo = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
-                let ?programInfo = cabalInfo
+                let info = ProgramInfo{program = cabalProgram, programPid = cabalProgramPid, programPidIO = cabalProgramPidIO}
+                let ?programInfo = info
 
                 -- Start loggers for stderr and stdout:
-                maybeKillDebugOut <- traverse (debugHandle $ ProgramOut cabalInfo) maybeHandleOut
-                maybeKillDebugErr <- traverse (debugHandle $ ProgramErr cabalInfo) maybeHandleErr
+                maybeKillDebugOut <- traverse (debugHandle $ ProgramOut info) maybeHandleOut
+                maybeKillDebugErr <- traverse (debugHandle $ ProgramErr info) maybeHandleErr
                 let kill = mask_ $ do
                         debugInfo $ "Cleaning up stdout reader for " <> program.name <> "."
                         sequence_ maybeKillDebugOut
@@ -264,15 +267,14 @@ programResource program = ProgramResource{..}
                         debugInfo $ "Process was killed with exit code " <> show exitCode
                         pure ()
                 let wait = do
-                        debugInfo $ "Waiting for " <> program.name <> " to finish."
-                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode ->
+                        debugInfo $ "Wait for " <> showCommandForUser cabal buildArgs
+                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode -> do
+                            debugInfo $ "Finished (" <> show exitCode <> "): " <> showCommandForUser cabal buildArgs
                             when (exitCode /= ExitSuccess) . assertFailure $
                                 "Program " <> program.name <> " failed with exit code " <> show exitCode
 
                 -- Wait for building program to finish
                 wait
-
-        buildProgram
 
         -- Find the program binary
         let findProgram :: IO FilePath
@@ -305,20 +307,29 @@ programResource program = ProgramResource{..}
                         debugInfo $ "Process was killed with exit code " <> show exitCode
                         pure ()
                 let wait = do
-                        debugInfo $ "Waiting for " <> program.name <> " to finish."
-                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode ->
+                        debugInfo $ "Wait for " <> showCommandForUser cabal findArgs
+                        bracketOnError (waitForProcess processHandle) (const kill) $ \exitCode -> do
+                            debugInfo $ "Finished (" <> show exitCode <> "): " <> showCommandForUser cabal findArgs
                             when (exitCode /= ExitSuccess) . assertFailure $
                                 "Program " <> program.name <> " failed with exit code " <> show exitCode
 
                 wait
 
-                programBin <- IO.hGetContents handleOut
+                -- The last line of output from list-bin should be the path:
+                findOut <- IO.hGetContents handleOut
+                programBins <- filterM doesFileExist (lines findOut)
+                case programBins of
+                    [] -> do
+                        let msg = "Could not find program binary for " <> program.name
+                        debugFail msg >> throwIO (ErrorCall msg)
+                    [programBin] -> do
+                        debugInfo $ "Found program binary at " <> programBin
+                        pure programBin
+                    (_programBin : _programBins) -> do
+                        let msg = unlines ("Found multiple program binaries for " <> program.name : programBins)
+                        debugFail msg >> throwIO (ErrorCall msg)
 
-                debugInfo $ "Found program binary at " <> programBin
-
-                pure programBin
-
-        programBin <- findProgram
+        programBin <- buildProgram >> findProgram
 
         debug Footer
 
@@ -346,6 +357,11 @@ programResource program = ProgramResource{..}
     -- Fork the program binary
     forkProgram :: FilePath -> EventlogSocketAddr -> IO ProgramHandle
     forkProgram programBin eventlogSocketAddr = do
+        -- Check if program exists:
+        programBinExists <- doesFileExist programBin
+        if programBinExists
+            then debugInfo $ "Program binary exists: " <> programBin
+            else debugFail $ "Program binary does NOT exist: " <> programBin
         -- Start program
         debugInfo $ "Launching program " <> programDesc
         inheritedEnv <- filter shouldInherit <$> getEnvironment

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -60,7 +60,7 @@ test_fibber =
                 { name = "fibber"
                 , args = ["40"]
                 , rtsopts = ["-l-au"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_fibber" fibber $ \eventlogSocket -> do
             assertEventlogWith eventlogSocket $
@@ -79,7 +79,7 @@ test_fibberCMain =
                 { name = "fibber-c-main"
                 , args = ["40"]
                 , rtsopts = ["-l-au"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_fibberCMain" fibberCMain $ \eventlogSocket -> do
             threadDelay 3_000_000
@@ -103,7 +103,7 @@ test_oddball_HasHeapProfSample =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "-hT", "-A256K", "-i0", "--eventlog-flush-interval=1"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_oddball_HasHeapProfSample" oddball $ \eventlogSocket -> do
             assertEventlogWith eventlogSocket $
@@ -122,7 +122,7 @@ test_oddball_NoAutomaticHeapSamples =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "-hT", "-A256K", "--eventlog-flush-interval=1", "--no-automatic-heap-samples"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_oddball_NoAutomaticHeapSamples" oddball $ \eventlogSocket -> do
             assertEventlogWith eventlogSocket $
@@ -142,7 +142,7 @@ test_oddball_Reconnect =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "-hT", "-A256K", "-i0", "--eventlog-flush-interval=1"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_oddball_Reconnect" oddball $ \eventlogSocket -> do
             -- Validate that reconnecting works and that each stream has a WallClockTime
@@ -160,7 +160,7 @@ test_oddball_HookOnReconnect =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "--eventlog-flush-interval=1"]
-                , eventlogSocketBuildFlags = []
+                , buildFlags = []
                 }
      in programTestFor "test_oddball_HookOnReconnect" oddball $ \eventlogSocket -> do
             -- Validate that reconnecting works and that each stream has a WallClockTime
@@ -182,7 +182,7 @@ test_oddball_ResetOnReconnect =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l", "-hT", "-A256K", "--eventlog-flush-interval=1", "--no-automatic-heap-samples"]
-                , eventlogSocketBuildFlags = ["+control"]
+                , buildFlags = ["--constraint=eventlog-socket+control"]
                 }
      in programTestFor "test_oddball_ResetOnReconnect" oddball $ \eventlogSocket -> do
             -- Validate that the event stream contains at least one heap
@@ -211,7 +211,7 @@ test_oddball_StartAndStopHeapProfiling =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "-hT", "-A256K", "--eventlog-flush-interval=1", "--no-automatic-heap-samples"]
-                , eventlogSocketBuildFlags = ["+control"]
+                , buildFlags = ["--constraint=eventlog-socket+control"]
                 }
      in programTestFor "test_oddball_StartAndStopHeapProfiling" oddball $ \eventlogSocket -> do
             assertEventlogWith' eventlogSocket $ \socket ->
@@ -236,7 +236,7 @@ test_oddball_RequestHeapCensus =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l", "-hT", "-A256K", "--eventlog-flush-interval=1", "--no-automatic-heap-samples"]
-                , eventlogSocketBuildFlags = ["+control"]
+                , buildFlags = ["--constraint=eventlog-socket+control"]
                 }
      in programTestFor "test_oddball_RequestHeapCensus" oddball $ \eventlogSocket -> do
             assertEventlogWith' eventlogSocket $ \socket ->
@@ -263,7 +263,7 @@ test_oddball_Junk (junkBefore, junkAfter) =
                 { name = "oddball"
                 , args = []
                 , rtsopts = ["-l-au", "-hT", "-A256K", "--eventlog-flush-interval=1", "--no-automatic-heap-samples"]
-                , eventlogSocketBuildFlags = ["+control"]
+                , buildFlags = ["--constraint=eventlog-socket+control"]
                 }
      in programTestFor ("test_oddball_Junk[" <> show junkBefore <> "," <> show junkAfter <> "]") oddball $ \eventlogSocket -> do
             assertEventlogWith' eventlogSocket $ \socket ->
@@ -286,7 +286,7 @@ test_customCommand =
                 { name = "custom-command"
                 , args = ["--forever"]
                 , rtsopts = ["-l-au", "--eventlog-flush-interval=1"]
-                , eventlogSocketBuildFlags = ["+control"]
+                , buildFlags = ["--constraint=eventlog-socket+control"]
                 }
      in programTestFor "test_customCommand" customCommand $ \eventlogSocket -> do
             assertEventlogWith' eventlogSocket $ \socket ->

--- a/eventlog-socket-tests/tests/Main.hs
+++ b/eventlog-socket-tests/tests/Main.hs
@@ -14,13 +14,16 @@ import GHC.Eventlog.Socket.Test
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import System.IO.Temp (withTempDirectory)
-import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty (defaultIngredients, defaultMainWithIngredients, includingOptions, testGroup)
 import Text.Read (readMaybe)
 
 main :: IO ()
 main = do
     -- Allow the user to overwrite the TCP port:
     tcpPort <- (fromMaybe "4242" . (readMaybe =<<)) <$> lookupEnv "GHC_EVENTLOG_INET_PORT"
+
+    -- Create list of tasty ingredients:
+    let ingredients = [includingOptions [keepProgramBuildOption]] <> defaultIngredients
 
     -- Create logger:
     withLogger $ do
@@ -29,7 +32,7 @@ main = do
             -- Base socket addresses
             let unixTests = tests <*> pure (EventlogSocketUnixAddr $ tmpDir </> "ghc_eventlog.sock")
             let inetTests = tests <*> pure (EventlogSocketInetAddr "127.0.0.1" tcpPort)
-            defaultMain . testGroup "Tests" . runProgramTests $ unixTests <> inetTests
+            defaultMainWithIngredients ingredients . testGroup "Tests" . runProgramTests $ unixTests <> inetTests
   where
     tests :: (HasLogger) => [EventlogSocketAddr -> ProgramTest]
     tests =


### PR DESCRIPTION
This PR (1) fixes an issue where the program build logic in `eventlog-socket-tests` accepts all lines printed to stdout by `cabal list-bin` to be binary paths, and (2) adds the `--keep-program-build` option to the test harness, which keeps the program build directories.